### PR TITLE
Use default factory for Email labels

### DIFF
--- a/src/mailtag/models.py
+++ b/src/mailtag/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Email(BaseModel):
@@ -9,4 +9,4 @@ class Email(BaseModel):
     sender_address: str
     sender_name: str
     body: str = ""
-    labels: list[str] = []
+    labels: list[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- ensure each Email instance gets its own labels list using Pydantic Field default factory

## Testing
- `uv run pytest -o addopts=''` *(fails: TypeError and AssertionError in multiple tests)*
- `uv run python - <<'PY'\nfrom mailtag.models import Email\n\nemail1 = Email(msg_id='1', subject='s', sender_address='a', sender_name='n')\nemail2 = Email(msg_id='2', subject='s2', sender_address='b', sender_name='n')\n\nemail1.labels.append('urgent')\nprint('Email1 labels:', email1.labels)\nprint('Email2 labels:', email2.labels)\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68ad6868a6a4832595ad9983c7db194e