### PR TITLE
Add MLX-based SemanticRouter classification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,14 @@ python src/main.py filters
 # Analyze Pass 3 files to find domain candidates (NEW)
 python src/main.py analyze-domains --output data/domain_candidates.json --min-emails 5 --top 50
 
-# Update domain database from reviewed candidates (NEW)
+# Update domain database from reviewed candidates
 python scripts/update_domain_db.py
+
+# Data management commands
+python src/main.py cleanup          # Remove old pass3 files (default: 30 days)
+python src/main.py cleanup --consolidate  # Also remove duplicate files per day
+python src/main.py db-stats         # Show database statistics and health check
+python src/main.py prune-db         # Remove low-confidence sender entries
 
 # Streamlit UI (alternative interface)
 streamlit run src/streamlit_app.py
@@ -187,6 +193,8 @@ Three JSON databases managed by `ClassificationDatabase` (`src/mailtag/database.
 
 All databases use lowercase normalization for sender addresses and domains to ensure consistent lookups.
 
+**Automatic Backups**: Databases are backed up to `db/backups/` once at the start of each classification run. Keeps 10 most recent backups per database.
+
 ### Configuration System
 
 Configuration loaded from `config.toml` with environment variable substitution:
@@ -228,11 +236,16 @@ class Email(BaseModel):
 ### Utilities
 
 - `src/mailtag/utils/domain_utils.py`: Domain extraction, normalization, and non-commercial domain detection with caching
-- `src/mailtag/utils/domain_analyzer.py`: **NEW** - Analyze Pass 3 files to identify commercial domain candidates for classification DB
-- `src/mailtag/utils/text_utils.py`: **NEW** - Intelligent email body processing (smart truncation, signature removal, keyword extraction)
+- `src/mailtag/utils/domain_analyzer.py`: Analyze Pass 3 files to identify commercial domain candidates for classification DB
+- `src/mailtag/utils/text_utils.py`: Intelligent email body processing (smart truncation, signature removal, keyword extraction)
+- `src/mailtag/utils/data_cleanup.py`: Pass3 file cleanup and consolidation utilities
+- `src/mailtag/utils/db_backup.py`: Database backup/restore with automatic rotation
+- `src/mailtag/utils/data_validation.py`: Email/domain normalization and database validation
 - `src/mailtag/retry.py`: Retry logic with exponential backoff for transient failures
 - `src/mailtag/metrics.py`: Performance metrics collection and reporting (extended with classification quality metrics)
 - `src/mailtag/folder_analyzer.py`: IMAP folder hierarchy analysis and category extraction
+
+See [docs/DATA_MANAGEMENT.md](docs/DATA_MANAGEMENT.md) for detailed data management documentation.
 
 ### Classification Metrics (NEW)
 

--- a/config.toml
+++ b/config.toml
@@ -60,3 +60,26 @@ metrics_enabled = true
 metrics_log_level = "INFO"
 # How often to log metrics summary (in minutes)
 metrics_log_interval_minutes = 10
+
+[mlx]
+# MLX-based classification (Apple Silicon optimized)
+# Set to false to use legacy litellm/Ollama instead
+enabled = true
+
+# Semantic Router (Signal 5) - embedding-based instant classification
+# Model for generating embeddings (nomic supports French and long context)
+embedding_model = "nomic-ai/nomic-embed-text-v1.5"
+# Minimum similarity score to accept semantic classification (0.0-1.0)
+score_threshold = 0.75
+# Pre-computed category embeddings file
+embeddings_file = "data/category_embeddings.npz"
+
+# LLM Fallback (Signal 6) - text generation when semantic routing fails
+# MLX-compatible model from mlx-community
+llm_model = "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
+# Confidence threshold for LLM classification
+llm_confidence = 0.85
+# Maximum tokens to generate
+llm_max_tokens = 256
+# Temperature for generation (lower = more deterministic)
+llm_temperature = 0.2

--- a/docs/DATA_MANAGEMENT.md
+++ b/docs/DATA_MANAGEMENT.md
@@ -1,0 +1,298 @@
+# Data Management Guide
+
+This guide covers the data management utilities for maintaining MailTag's databases and data files.
+
+## Overview
+
+MailTag generates and maintains several data files during operation:
+
+| Directory | Contents |
+|-----------|----------|
+| `db/` | Classification databases (JSON) |
+| `db/backups/` | Automatic database backups |
+| `data/` | Runtime data files (pass3 outputs, folder cache) |
+
+## CLI Commands
+
+### Database Statistics
+
+View statistics and health check for all databases:
+
+```bash
+python src/main.py db-stats
+```
+
+**Output includes:**
+- Number of entries in each database
+- High-confidence sender entries (10+ occurrences)
+- Unique categories in domain database
+- File sizes
+
+### Data Cleanup
+
+Remove old pass3 files and validate databases:
+
+```bash
+# Remove pass3 files older than 30 days (default)
+python src/main.py cleanup
+
+# Custom age threshold
+python src/main.py cleanup --max-age 14
+
+# Also consolidate duplicate files from same day
+python src/main.py cleanup --consolidate
+
+# Preview without deleting (dry run)
+python src/main.py cleanup --dry-run
+```
+
+**What gets cleaned:**
+- `pass3_manual_matching_*.json` files older than threshold
+- Duplicate files from same day (keeps first and last)
+
+### Prune Low-Confidence Entries
+
+Remove sender entries with few occurrences:
+
+```bash
+# Remove entries with less than 3 occurrences (default)
+python src/main.py prune-db
+
+# Custom threshold
+python src/main.py prune-db --min-count 5
+
+# Preview without modifying
+python src/main.py prune-db --dry-run
+```
+
+**Why prune?**
+- Single-occurrence entries provide low classification signal
+- Reduces database size and lookup time
+- Improves signal-to-noise ratio
+
+## Database Files
+
+### sender_classification_db.json
+
+Historical AI classification suggestions per sender.
+
+```json
+{
+  "newsletter@example.com": {
+    "Marketing/Newsletters": 15,
+    "Promotions": 2
+  }
+}
+```
+
+- Key: Normalized sender email (lowercase)
+- Value: Category counts from AI suggestions
+- Used by Signal 3 (Historical Database) when count >= 10
+
+### validated_classification_db.json
+
+Manually validated sender-to-category mappings.
+
+```json
+{
+  "support@company.com": "Services/Support"
+}
+```
+
+- Key: Normalized sender email
+- Value: Definitive category
+- Used by Signal 1 (highest priority, 100% confidence)
+
+### domain_classifications.json
+
+Domain-level classification rules for commercial senders.
+
+```json
+{
+  "amazon.com": "Shopping/Amazon",
+  "github.com": "Tech/Development"
+}
+```
+
+- Key: Normalized domain (lowercase)
+- Value: Category
+- Used by Signal 4 (90% confidence)
+- Skips non-commercial domains (gmail.com, yahoo.com, etc.)
+
+## Automatic Backups
+
+Databases are automatically backed up:
+
+1. **When**: Once at the start of each classification run
+2. **Where**: `db/backups/`
+3. **Format**: `{database_name}_{YYYYMMDD}_{HHMMSS}.json`
+4. **Retention**: Keeps 10 most recent backups per database
+
+### Manual Backup
+
+```python
+from mailtag.utils.db_backup import backup_all_databases
+
+backup_all_databases(Path("db"))
+```
+
+### Restore from Backup
+
+```python
+from mailtag.utils.db_backup import restore_database
+
+restore_database(
+    backup_path=Path("db/backups/sender_classification_db_20251230_120000.json"),
+    db_path=Path("db/sender_classification_db.json")
+)
+```
+
+### List Backups
+
+```python
+from mailtag.utils.db_backup import list_backups
+
+backups = list_backups(Path("db/backups"))
+for b in backups:
+    print(f"{b['name']}: {b['size_bytes']} bytes, created {b['created']}")
+```
+
+## Data Validation
+
+### Validate Databases
+
+Check for data quality issues:
+
+```python
+from mailtag.utils.data_validation import (
+    validate_domain_classifications,
+    validate_sender_classifications
+)
+
+# Check domain database
+issues = validate_domain_classifications(Path("db/domain_classifications.json"))
+for issue in issues:
+    print(f"Issue: {issue}")
+
+# Check sender database
+issues = validate_sender_classifications(Path("db/sender_classification_db.json"))
+```
+
+**Detects:**
+- Malformed domains (trailing `>`, invalid format)
+- Empty categories
+- Sender addresses needing normalization
+- Invalid category data types
+
+### Fix Common Issues
+
+```python
+from mailtag.utils.data_validation import fix_domain_classifications
+
+# Auto-fix malformed domains
+fixed = fix_domain_classifications(Path("db/domain_classifications.json"))
+print(f"Fixed {fixed} domains")
+```
+
+## Email Normalization
+
+All emails and domains are normalized before storage:
+
+```python
+from mailtag.utils.data_validation import normalize_email, normalize_domain
+
+# Email normalization
+normalize_email("<John.Doe@EXAMPLE.COM>")  # → "john.doe@example.com"
+normalize_email("Name <user@host.com>")     # → "user@host.com"
+
+# Domain normalization
+normalize_domain("Example.COM>")  # → "example.com"
+```
+
+**Normalization rules:**
+- Strip angle brackets `< >`
+- Decode RFC 2047 encoded headers
+- Convert to lowercase
+- Strip whitespace
+
+## Pass3 Files
+
+Pass3 files contain emails that need manual classification review.
+
+### File Format
+
+```json
+{
+  "timestamp": "2025-12-30T12:00:00",
+  "emails_for_manual_matching": [
+    {
+      "msg_id": "...",
+      "sender": "unknown@domain.com",
+      "subject": "...",
+      "suggested_category": "À Classer"
+    }
+  ]
+}
+```
+
+### Cleanup Strategy
+
+1. **Age-based**: Remove files older than 30 days
+2. **Consolidation**: When multiple files exist for same day, keep only first and last
+
+### Statistics
+
+```python
+from mailtag.utils.data_cleanup import get_pass3_file_stats
+
+stats = get_pass3_file_stats(Path("data"))
+print(f"Total files: {stats['total_files']}")
+print(f"Date range: {stats['oldest_date']} to {stats['newest_date']}")
+print(f"Files per day: {stats['files_by_date']}")
+```
+
+## Best Practices
+
+1. **Run cleanup weekly**: `python src/main.py cleanup`
+2. **Check db-stats periodically**: Monitor database growth
+3. **Prune after initial setup**: Remove single-occurrence entries once you have enough data
+4. **Review backups**: Ensure backups are being created
+5. **Validate after manual edits**: Run validation if you edit databases manually
+
+## Troubleshooting
+
+### "File not found" errors
+
+If `validated_classification_db.json` is missing:
+```bash
+echo "{}" > db/validated_classification_db.json
+```
+
+### Malformed domain entries
+
+Run the fix command:
+```python
+from mailtag.utils.data_validation import fix_domain_classifications
+fix_domain_classifications(Path("db/domain_classifications.json"))
+```
+
+### Pass3 files accumulating
+
+Enable regular cleanup:
+```bash
+# Add to crontab or scheduled task
+python src/main.py cleanup --max-age 30
+```
+
+### Restore corrupted database
+
+```python
+from mailtag.utils.db_backup import list_backups, restore_database
+
+# Find recent backup
+backups = list_backups(Path("db/backups"))
+latest = backups[-1]  # Most recent
+
+# Restore
+restore_database(latest['path'], Path("db/sender_classification_db.json"))
+```

--- a/docs/MLX_MIGRATION_PLAN.md
+++ b/docs/MLX_MIGRATION_PLAN.md
@@ -1,0 +1,228 @@
+# Plan: Migration vers MLX pour MailTag
+
+## Décisions Prises
+
+- **Architecture:** Option C - Hybride (Embeddings MLX + LLM MLX fallback)
+- **Fallback litellm:** Non - MLX uniquement (projet Mac-only)
+- **Embedding:** `nomic-embed-text-v1.5` (précis, contexte long, bon en français)
+- **LLM:** `Mistral-7B-Instruct-v0.3-4bit` (équilibré, fiable)
+
+---
+
+## Architecture Cible
+
+```
+Signal 1: Validated DB (100%)
+Signal 2: Server Labels (95%)
+Signal 3: Historical DB (90%)
+Signal 4: Domain Rules (90%)
+Signal 5: Semantic Router MLX (85%) ← NOUVEAU - Embeddings instantanés
+Signal 6: LLM MLX Fallback (0.85 threshold) ← Remplace litellm
+```
+
+### Configuration
+
+```toml
+[mlx]
+enabled = true
+
+# Semantic Router (Signal 5)
+embedding_model = "nomic-ai/nomic-embed-text-v1.5"
+score_threshold = 0.75
+
+# LLM Fallback (Signal 6)
+llm_model = "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
+llm_confidence = 0.85
+```
+
+---
+
+## Gains Attendus
+
+### Performance
+- **5-6x plus rapide** pour la classification AI
+- **Classification instantanée** via embeddings (nouveau signal)
+- **32% mémoire économisée** vs Ollama
+
+### Simplicité
+- **Pas de serveur Ollama** à démarrer/maintenir
+- Configuration unifiée dans `config.toml`
+- Dépendances Python uniquement
+
+### Coût
+- **0 API calls** = gratuit
+- Exécution 100% locale
+
+### Flexibilité
+- Changement de modèle via config uniquement
+- Support des modèles mlx-community (1000+)
+
+---
+
+## Risques et Mitigations
+
+| Risque | Impact | Mitigation |
+|--------|--------|------------|
+| Apple Silicon only | Accepté | Projet Mac-only confirmé |
+| Qualité classification | Moyen | Tests A/B vs configuration actuelle |
+| Nouvelles dépendances | Faible | mlx, mlx-lm sont stables |
+| Accuracy embeddings | Moyen | Threshold 0.75 + LLM fallback |
+
+---
+
+## Plan d'Implémentation
+
+### Phase 1: Infrastructure MLX
+**Fichiers à créer:**
+
+1. `src/mailtag/mlx_provider.py`
+   ```python
+   class MLXEmbedder:
+       """Génère embeddings avec nomic-embed-text-v1.5"""
+       def __init__(self, model_name: str)
+       def encode(self, texts: list[str]) -> np.ndarray
+
+   class MLXLLM:
+       """Génère texte avec Mistral-7B via mlx-lm"""
+       def __init__(self, model_name: str)
+       def generate(self, prompt: str, max_tokens: int) -> str
+   ```
+
+2. `src/mailtag/config.py` - Ajouter:
+   ```python
+   @dataclass
+   class MLXConfig:
+       enabled: bool = True
+       embedding_model: str = "nomic-ai/nomic-embed-text-v1.5"
+       score_threshold: float = 0.75
+       llm_model: str = "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
+       llm_confidence: float = 0.85
+   ```
+
+### Phase 2: Semantic Router
+**Fichiers à créer:**
+
+3. `src/mailtag/semantic_router.py`
+   ```python
+   class SemanticRouter:
+       """Classification par similarité sémantique"""
+       def __init__(self, embedder: MLXEmbedder, categories_file: Path)
+       def build_category_embeddings(self, validated_db: dict)
+       def route(self, text: str) -> tuple[str, float]  # (category, score)
+       def save_embeddings(self, path: Path)
+       def load_embeddings(self, path: Path)
+   ```
+
+4. `scripts/build_category_embeddings.py`
+   - Charge `db/validated_classification_db.json`
+   - Génère embeddings par catégorie (centroïde des exemples)
+   - Sauvegarde dans `data/category_embeddings.npz`
+
+### Phase 3: Intégration Classifier
+**Fichier à modifier:**
+
+5. `src/mailtag/classifier.py`
+   - Supprimer import litellm
+   - Ajouter `_get_category_from_semantic_router()` (Signal 5)
+   - Modifier `_get_category_from_ai()` pour utiliser `MLXLLM` (Signal 6)
+   - Lazy loading des modèles MLX
+
+### Phase 4: Configuration
+**Fichiers à modifier:**
+
+6. `config.toml` - Ajouter section:
+   ```toml
+   [mlx]
+   enabled = true
+   embedding_model = "nomic-ai/nomic-embed-text-v1.5"
+   score_threshold = 0.75
+   llm_model = "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
+   llm_confidence = 0.85
+   ```
+
+7. `pyproject.toml` - Modifier dépendances:
+   ```toml
+   dependencies = [
+       # Remplacer litellm par:
+       "mlx>=0.18",
+       "mlx-lm>=0.18",
+       "sentence-transformers>=2.2",  # Pour nomic embeddings
+       "numpy>=1.24",
+   ]
+   ```
+
+### Phase 5: Tests
+**Fichiers à créer:**
+
+8. `tests/test_mlx_provider.py`
+9. `tests/test_semantic_router.py`
+
+---
+
+## Fichiers Impactés (Résumé)
+
+| Fichier | Action | Lignes estimées |
+|---------|--------|-----------------|
+| `src/mailtag/mlx_provider.py` | Créer | ~150 |
+| `src/mailtag/semantic_router.py` | Créer | ~120 |
+| `src/mailtag/classifier.py` | Modifier | ~50 changées |
+| `src/mailtag/config.py` | Modifier | ~20 ajoutées |
+| `config.toml` | Modifier | ~10 ajoutées |
+| `pyproject.toml` | Modifier | ~5 changées |
+| `scripts/build_category_embeddings.py` | Créer | ~80 |
+| `tests/test_mlx_provider.py` | Créer | ~100 |
+| `tests/test_semantic_router.py` | Créer | ~100 |
+
+**Total:** ~9 fichiers, ~635 lignes
+
+---
+
+## Réutilisation des Données Existantes
+
+| Fichier | Usage actuel | Usage MLX |
+|---------|--------------|-----------|
+| `db/validated_classification_db.json` | Signal 1 (100%) | **Inchangé** + source pour embeddings catégories |
+| `db/sender_classification_db.json` | Signal 3 (historique) | **Inchangé** |
+| `db/domain_classifications.json` | Signal 4 (domaines) | **Inchangé** |
+| `data/imap_folders.json` | Liste catégories | **Inchangé** |
+| `data/category_embeddings.npz` | N/A | **NOUVEAU** - Généré depuis validated_db |
+
+### Génération des Embeddings Catégories
+
+Le script `build_category_embeddings.py`:
+```python
+# 1. Charge validated_db
+validated_db = load("db/validated_classification_db.json")
+# {"sender@shop.com": "Inbox/Commerce", ...}
+
+# 2. Regroupe par catégorie + récupère exemples de subjects/bodies
+categories = {}
+for sender, category in validated_db.items():
+    if category not in categories:
+        categories[category] = []
+    # Ajoute des exemples représentatifs (depuis historical_db ou imap_folders)
+    categories[category].append(f"Email de {sender}")
+
+# 3. Calcule embedding centroïde par catégorie
+for category, examples in categories.items():
+    embeddings = model.encode(examples)
+    category_embeddings[category] = embeddings.mean(axis=0)
+
+# 4. Sauvegarde
+np.savez("data/category_embeddings.npz", **category_embeddings)
+```
+
+**Important:** Les Signals 1-4 restent identiques. MLX ajoute seulement Signal 5 (semantic) et remplace litellm pour Signal 6 (LLM).
+
+---
+
+## Ordre d'Exécution
+
+1. Config (`config.py`, `config.toml`, `pyproject.toml`)
+2. MLX Provider (`mlx_provider.py`)
+3. Semantic Router (`semantic_router.py`)
+4. Script embeddings (`build_category_embeddings.py`)
+5. Intégration Classifier (`classifier.py`)
+6. Tests
+7. Documentation (CLAUDE.md)
+8. **Générer embeddings initiaux** via `python scripts/build_category_embeddings.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,8 @@ indent-style = "space"
 
 # Like Black, respect magic trailing commas.
 skip-magic-trailing-comma = false
+
+[dependency-groups]
+dev = [
+    "bandit>=1.9.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "mlx-lm>=0.18.0",
     "sentence-transformers>=2.2.0",
     "numpy>=1.24.0",
+    "einops>=0.8.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ authors = [
 ]
 dependencies = [
     "beautifulsoup4>=4.13.4",
-    "litellm>=1.73.6",
-    "ollama>=0.3.0",
     "streamlit>=1.46.1",
     "loguru>=0.7.2",
     "pytest-mock>=3.14.1",
@@ -33,6 +31,11 @@ dependencies = [
     "google>=3.0.0",
     "pydantic>=2.11.7",
     "dotenv>=0.9.9",
+    # MLX dependencies (Apple Silicon optimized)
+    "mlx>=0.18.0",
+    "mlx-lm>=0.18.0",
+    "sentence-transformers>=2.2.0",
+    "numpy>=1.24.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,76 @@
+# scripts/
+
+Utility scripts for development, deployment, and database management.
+
+## Shell Scripts
+
+### start.sh
+Start the main application.
+
+### run.sh
+Run classification with default settings.
+
+### cli.sh
+Launch the CLI interface.
+
+### streamlit.sh
+Start the Streamlit web UI.
+```bash
+./scripts/streamlit.sh
+# Equivalent to: streamlit run src/streamlit_app.py
+```
+
+### webhook.sh
+Start the FastAPI webhook server.
+```bash
+./scripts/webhook.sh
+# Equivalent to: python src/webhook.py
+```
+
+### test.sh
+Run the test suite.
+```bash
+./scripts/test.sh
+# Equivalent to: uv run pytest
+```
+
+## Python Scripts
+
+### build_domain_database.py
+Build domain classification database from existing data.
+
+### update_domain_db.py
+Update domain database from reviewed candidates.
+
+**Usage:**
+```bash
+# First, generate candidates
+python src/main.py analyze-domains --output data/domain_candidates.json
+
+# Review and edit domain_candidates.json
+
+# Then update the database
+python scripts/update_domain_db.py
+```
+
+### inject_filters.py
+Inject email filter rules into email client configuration.
+
+### check_duplicates.py
+Check for duplicate entries in databases.
+
+## Running Scripts
+
+```bash
+# Shell scripts
+chmod +x scripts/*.sh
+./scripts/start.sh
+
+# Python scripts
+python scripts/update_domain_db.py
+```
+
+## Notes
+- Shell scripts assume `uv` is available in PATH
+- Python scripts should be run from project root
+- Check script contents for specific arguments/options

--- a/scripts/build_category_embeddings.py
+++ b/scripts/build_category_embeddings.py
@@ -261,9 +261,7 @@ def build_embeddings(
 
 def main():
     """Main entry point."""
-    parser = argparse.ArgumentParser(
-        description="Build category embeddings for semantic routing"
-    )
+    parser = argparse.ArgumentParser(description="Build category embeddings for semantic routing")
     parser.add_argument(
         "--output",
         type=Path,

--- a/scripts/build_category_embeddings.py
+++ b/scripts/build_category_embeddings.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Build category embeddings from existing classification databases.
+
+This script generates embeddings for each category based on:
+1. Validated sender-category mappings (db/validated_classification_db.json)
+2. IMAP folder structure (data/imap_folders.json)
+3. Historical classification patterns (db/sender_classification_db.json)
+
+The embeddings are saved to data/category_embeddings.npz for use by
+the SemanticRouter during classification.
+
+Usage:
+    python scripts/build_category_embeddings.py [--output PATH] [--model MODEL]
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from loguru import logger
+
+
+def load_json_file(path: Path) -> dict | list | None:
+    """Load a JSON file, returning None if it doesn't exist."""
+    if not path.exists():
+        logger.warning(f"File not found: {path}")
+        return None
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse JSON from {path}: {e}")
+        return None
+
+
+def extract_categories_from_validated_db(validated_db: dict[str, str]) -> dict[str, list[str]]:
+    """Extract category examples from validated database.
+
+    Args:
+        validated_db: Dict mapping sender email to category
+
+    Returns:
+        Dict mapping category to list of example texts
+    """
+    category_examples: dict[str, list[str]] = {}
+
+    for sender, category in validated_db.items():
+        if category not in category_examples:
+            category_examples[category] = []
+
+        # Create representative text from sender
+        domain = sender.split("@")[-1] if "@" in sender else sender
+        company = domain.split(".")[0] if "." in domain else domain
+
+        # Add multiple variations for better embedding
+        examples = [
+            f"Email from {company}",
+            f"Message from {domain}",
+            f"Correspondence from {sender}",
+            f"Category {category} email from {company}",
+        ]
+        category_examples[category].extend(examples)
+
+    return category_examples
+
+
+def extract_categories_from_folders(folders: list[str]) -> dict[str, list[str]]:
+    """Extract category examples from folder names.
+
+    Args:
+        folders: List of folder paths (e.g., "Inbox/Commerce/Amazon")
+
+    Returns:
+        Dict mapping category to list of example texts
+    """
+    category_examples: dict[str, list[str]] = {}
+
+    for folder in folders:
+        # Use full folder path as category
+        if folder not in category_examples:
+            category_examples[folder] = []
+
+        # Extract meaningful parts from folder name
+        parts = folder.split("/")
+        folder_name = parts[-1] if parts else folder
+
+        # Create example texts based on folder name
+        examples = [
+            f"Email belonging to {folder_name}",
+            f"Message for category {folder_name}",
+            f"Content related to {folder_name}",
+            f"{folder} folder email",
+        ]
+        category_examples[folder].extend(examples)
+
+        # If folder has parent, add context
+        if len(parts) > 1:
+            parent = parts[-2]
+            examples.append(f"{folder_name} under {parent}")
+
+    return category_examples
+
+
+def extract_categories_from_history(sender_db: dict[str, dict]) -> dict[str, list[str]]:
+    """Extract category examples from historical sender database.
+
+    Args:
+        sender_db: Dict mapping sender to category counts
+
+    Returns:
+        Dict mapping category to list of example texts
+    """
+    category_examples: dict[str, list[str]] = {}
+
+    for sender, categories in sender_db.items():
+        if not isinstance(categories, dict):
+            continue
+
+        # Find dominant category for this sender
+        dominant_category = max(categories, key=categories.get)
+        count = categories[dominant_category]
+
+        # Only use high-confidence senders (10+ occurrences)
+        if count < 10:
+            continue
+
+        if dominant_category not in category_examples:
+            category_examples[dominant_category] = []
+
+        domain = sender.split("@")[-1] if "@" in sender else sender
+        company = domain.split(".")[0] if "." in domain else domain
+
+        category_examples[dominant_category].append(f"Frequent email from {company}")
+
+    return category_examples
+
+
+def merge_examples(
+    *example_dicts: dict[str, list[str]],
+    max_per_category: int = 20,
+) -> dict[str, list[str]]:
+    """Merge multiple example dictionaries, deduplicating.
+
+    Args:
+        *example_dicts: Variable number of example dictionaries
+        max_per_category: Maximum examples to keep per category
+
+    Returns:
+        Merged dictionary with deduplicated examples
+    """
+    merged: dict[str, list[str]] = {}
+
+    for examples in example_dicts:
+        for category, texts in examples.items():
+            if category not in merged:
+                merged[category] = []
+            merged[category].extend(texts)
+
+    # Deduplicate and limit
+    for category in merged:
+        unique = list(dict.fromkeys(merged[category]))  # Preserve order, remove dupes
+        merged[category] = unique[:max_per_category]
+
+    return merged
+
+
+def build_embeddings(
+    output_path: Path,
+    model_name: str,
+    validated_db_path: Path,
+    folders_path: Path,
+    sender_db_path: Path,
+) -> bool:
+    """Build and save category embeddings.
+
+    Args:
+        output_path: Path to save embeddings (.npz file)
+        model_name: Embedding model name
+        validated_db_path: Path to validated classification database
+        folders_path: Path to IMAP folders JSON
+        sender_db_path: Path to sender classification database
+
+    Returns:
+        True if successful, False otherwise
+    """
+    from mailtag.mlx_provider import MLXEmbedder
+    from mailtag.semantic_router import SemanticRouter
+
+    # Collect examples from all sources
+    all_examples: list[dict[str, list[str]]] = []
+
+    # 1. Validated database (highest priority)
+    validated_db = load_json_file(validated_db_path)
+    if validated_db and isinstance(validated_db, dict):
+        examples = extract_categories_from_validated_db(validated_db)
+        all_examples.append(examples)
+        logger.info(f"Extracted {len(examples)} categories from validated_db")
+
+    # 2. IMAP folders structure
+    folders_data = load_json_file(folders_path)
+    if folders_data:
+        # Handle both list and dict formats
+        if isinstance(folders_data, list):
+            folders = folders_data
+        elif isinstance(folders_data, dict):
+            folders = folders_data.get("folders", [])
+        else:
+            folders = []
+
+        if folders:
+            examples = extract_categories_from_folders(folders)
+            all_examples.append(examples)
+            logger.info(f"Extracted {len(examples)} categories from folder structure")
+
+    # 3. Historical sender database
+    sender_db = load_json_file(sender_db_path)
+    if sender_db and isinstance(sender_db, dict):
+        examples = extract_categories_from_history(sender_db)
+        all_examples.append(examples)
+        logger.info(f"Extracted {len(examples)} categories from sender history")
+
+    if not all_examples:
+        logger.error("No category data found. Please ensure databases exist.")
+        return False
+
+    # Merge all examples
+    merged = merge_examples(*all_examples)
+    logger.info(f"Total categories after merge: {len(merged)}")
+
+    # Filter categories with too few examples
+    filtered = {cat: examples for cat, examples in merged.items() if len(examples) >= 2}
+    logger.info(f"Categories with 2+ examples: {len(filtered)}")
+
+    if not filtered:
+        logger.error("No categories have enough examples to build embeddings")
+        return False
+
+    # Build embeddings
+    logger.info(f"Loading embedding model: {model_name}")
+    embedder = MLXEmbedder(model_name)
+    router = SemanticRouter(embedder)
+
+    logger.info("Building category embeddings...")
+    router.build_from_examples(filtered)
+
+    # Save embeddings
+    success = router.save_embeddings(output_path)
+    if success:
+        logger.info(f"Successfully saved embeddings to {output_path}")
+        logger.info(f"Categories: {len(router.categories)}")
+        logger.info(f"Sample categories: {router.categories[:10]}")
+    else:
+        logger.error(f"Failed to save embeddings to {output_path}")
+
+    return success
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Build category embeddings for semantic routing"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/category_embeddings.npz"),
+        help="Output path for embeddings file",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="nomic-ai/nomic-embed-text-v1.5",
+        help="Embedding model name",
+    )
+    parser.add_argument(
+        "--validated-db",
+        type=Path,
+        default=Path("db/validated_classification_db.json"),
+        help="Path to validated classification database",
+    )
+    parser.add_argument(
+        "--folders",
+        type=Path,
+        default=Path("data/imap_folders.json"),
+        help="Path to IMAP folders JSON",
+    )
+    parser.add_argument(
+        "--sender-db",
+        type=Path,
+        default=Path("db/sender_classification_db.json"),
+        help="Path to sender classification database",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    # Configure logging
+    logger.remove()
+    level = "DEBUG" if args.verbose else "INFO"
+    logger.add(sys.stderr, level=level, format="{time:HH:mm:ss} | {level:<7} | {message}")
+
+    logger.info("Building category embeddings...")
+    logger.info(f"Output: {args.output}")
+    logger.info(f"Model: {args.model}")
+
+    success = build_embeddings(
+        output_path=args.output,
+        model_name=args.model,
+        validated_db_path=args.validated_db,
+        folders_path=args.folders,
+        sender_db_path=args.sender_db,
+    )
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_domain_db.py
+++ b/scripts/update_domain_db.py
@@ -24,7 +24,7 @@ def update_domain_db(candidates_file: Path, domain_db_file: Path) -> tuple[int, 
     try:
         with open(candidates_file) as f:
             data = json.load(f)
-    except (json.JSONDecodeError, IOError) as e:
+    except (OSError, json.JSONDecodeError) as e:
         print(f"Error loading candidates file: {e}")
         return 0, 0
 
@@ -32,8 +32,8 @@ def update_domain_db(candidates_file: Path, domain_db_file: Path) -> tuple[int, 
     try:
         with open(domain_db_file) as f:
             domain_db = json.load(f)
-    except (json.JSONDecodeError, IOError):
-        print(f"Warning: Could not load existing DB, creating new one")
+    except (OSError, json.JSONDecodeError):
+        print("Warning: Could not load existing DB, creating new one")
         domain_db = {}
 
     # Add new entries

--- a/src/mailtag/CLAUDE.md
+++ b/src/mailtag/CLAUDE.md
@@ -1,0 +1,53 @@
+# src/mailtag/
+
+Core package for email classification and organization.
+
+## Key Modules
+
+### Classification Engine
+- **classifier.py** - `Classifier` class implementing AMSC (Adaptive Multi-Signal Classification)
+  - `classify_email()` - Main entry point, tries 5 signals in priority order
+  - `_get_category_from_validated_db()` - Signal 1: Validated mappings (100% confidence)
+  - `_get_category_from_labels()` - Signal 2: Server-side labels (95%)
+  - `_get_category_from_history()` - Signal 3: Historical patterns (90%+)
+  - `_get_category_from_domain()` - Signal 4: Domain rules (90%)
+  - `_get_category_from_ai()` - Signal 5: AI fallback with JSON confidence scoring
+  - `export_metrics()` / `log_metrics_summary()` - Classification analytics
+
+### Database Layer
+- **database.py** - `ClassificationDatabase` class managing 3 JSON databases
+  - `update_suggestion()` - Record AI suggestions
+  - `promote_to_validated()` - Move to validated DB
+  - `get_category_by_domain()` / `store_domain_classification()` - Domain rules
+  - All lookups use lowercase-normalized emails/domains
+
+### Email Providers
+- **providers.py** - `EmailProvider` abstract base class
+  - `connect()` - Context manager for connection lifecycle
+  - `get_emails()` - Fetch emails with filters
+  - `move_email()` - Move single email
+
+- **imap_service.py** - `ImapService` implementation
+  - `get_email_headers()` - Headers-only fetch for Pass 1
+  - `get_full_emails()` - Full body fetch for Pass 3
+  - `batch_move_emails()` - Efficient bulk operations
+  - `get_folder_hierarchy()` - Cached folder structure
+
+- **gmail_service.py** - `GmailService` implementation
+  - OAuth-based authentication
+  - Label management via Gmail API
+
+### Supporting Modules
+- **config.py** - Configuration dataclasses with env var substitution
+- **models.py** - `Email` Pydantic model
+- **metrics.py** - Performance metrics collection
+- **retry.py** - Exponential backoff retry logic
+- **folder_analyzer.py** - IMAP folder hierarchy analysis
+- **filter_generator.py** - Email filter rule generation
+- **gmail_auth.py** - OAuth flow for Gmail
+
+## Design Patterns
+- Provider pattern for email backends
+- Context managers for connections
+- Batch operations over individual calls
+- Lowercase normalization for all lookups

--- a/src/mailtag/classifier.py
+++ b/src/mailtag/classifier.py
@@ -1,8 +1,8 @@
 import hashlib
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import litellm
 import yaml
 from loguru import logger
 
@@ -14,11 +14,15 @@ from .models import Email
 from .utils.domain_utils import extract_domain, is_non_commercial_domain_cached
 from .utils.text_utils import smart_truncate
 
+if TYPE_CHECKING:
+    from .mlx_provider import MLXLLM, MLXEmbedder
+    from .semantic_router import SemanticRouter
+
 
 class Classifier:
     """
     Classifies emails using a multi-signal strategy, prioritizing server-side
-    labels, then historical data, and finally an AI model.
+    labels, then historical data, semantic routing, and finally an AI model.
     """
 
     def __init__(self, config: AppConfig, database: ClassificationDatabase):
@@ -26,6 +30,12 @@ class Classifier:
         self.proposal_file = Path("proposals.log")
         self.database = database
         self.ai_cache = {}  # Simple in-memory cache for AI responses
+
+        # MLX components (lazy loaded)
+        self._embedder: MLXEmbedder | None = None
+        self._semantic_router: SemanticRouter | None = None
+        self._mlx_llm: MLXLLM | None = None
+        self._mlx_initialized = False
 
         # Use either folder analyzer or static schema based on configuration
         if config.general.use_imap_folders_for_classification:
@@ -36,6 +46,67 @@ class Classifier:
             self.folder_analyzer = None
             self.categories = self._load_categories_from_schema()
             logger.info(f"Using static classification schema with {len(self.categories)} categories")
+
+    def _init_mlx_components(self) -> bool:
+        """Lazy initialize MLX components when first needed.
+
+        Returns:
+            True if initialization successful, False otherwise
+        """
+        if self._mlx_initialized:
+            return self._semantic_router is not None
+
+        self._mlx_initialized = True
+
+        if not self.config.mlx.enabled:
+            logger.debug("MLX classification is disabled in config")
+            return False
+
+        try:
+            from .mlx_provider import MLXLLM, MLXEmbedder
+            from .semantic_router import SemanticRouter
+
+            # Initialize embedder
+            logger.info(f"Initializing MLX embedder with model: {self.config.mlx.embedding_model}")
+            self._embedder = MLXEmbedder(self.config.mlx.embedding_model)
+
+            # Initialize semantic router
+            self._semantic_router = SemanticRouter(
+                self._embedder,
+                score_threshold=self.config.mlx.score_threshold,
+            )
+
+            # Try to load pre-computed embeddings
+            embeddings_path = Path(self.config.mlx.embeddings_file)
+            if embeddings_path.exists():
+                if self._semantic_router.load_embeddings(embeddings_path):
+                    num_cats = self._semantic_router.num_categories
+                    logger.info(f"Loaded {num_cats} category embeddings from {embeddings_path}")
+                else:
+                    logger.warning(f"Failed to load embeddings from {embeddings_path}")
+            else:
+                logger.warning(
+                    f"No embeddings file found at {embeddings_path}. "
+                    "Run 'python scripts/build_category_embeddings.py' to generate."
+                )
+
+            # Initialize LLM for fallback
+            logger.info(f"Initializing MLX LLM with model: {self.config.mlx.llm_model}")
+            self._mlx_llm = MLXLLM(
+                model_name=self.config.mlx.llm_model,
+                max_tokens=self.config.mlx.llm_max_tokens,
+                temperature=self.config.mlx.llm_temperature,
+            )
+
+            logger.info("MLX components initialized successfully")
+            return True
+
+        except ImportError as e:
+            logger.warning(f"MLX dependencies not available: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Failed to initialize MLX components: {e}")
+            return False
 
     def _load_categories_from_schema(self) -> list[str]:
         """Loads classification categories from the YAML file (legacy method)."""
@@ -122,6 +193,47 @@ class Classifier:
         logger.debug(f"No domain classification found for: {domain}")
         return None
 
+    def _get_category_from_semantic_router(self, email: Email) -> tuple[str | None, float]:
+        """
+        Signal 5: Use semantic router for embedding-based classification.
+
+        Returns:
+            Tuple of (category, confidence_score) or (None, 0.0) if no match
+        """
+        if not self._init_mlx_components():
+            return None, 0.0
+
+        if self._semantic_router is None or self._semantic_router.num_categories == 0:
+            logger.debug("Semantic router not available or no categories loaded")
+            return None, 0.0
+
+        # Build query text from email
+        sender = email.sender_name or email.sender_address or "Unknown"
+        query_text = f"Email from {sender}: {email.subject}"
+
+        # Add truncated body if available
+        if email.body:
+            truncated_body = self._truncate_body(email.body, max_chars=500)
+            if truncated_body:
+                query_text += f"\n{truncated_body}"
+
+        # Route using semantic similarity
+        category, score = self._semantic_router.route(query_text)
+
+        if category:
+            # Validate category exists in our known categories
+            if category in self.categories:
+                logger.debug(
+                    f"Semantic router matched '{category}' with score {score:.3f}"
+                )
+                return category, score
+            else:
+                logger.debug(
+                    f"Semantic router suggested unknown category '{category}', ignoring"
+                )
+
+        return None, score
+
     def _get_cache_key(self, email: Email) -> str:
         """Generate a cache key for AI responses based on sender and subject."""
         sender = email.sender_address or "Unknown"
@@ -201,14 +313,23 @@ class Classifier:
 
     def _get_category_from_ai(self, email: Email) -> str:
         """
-        Signal 5: Fallback to the AI model for classification with confidence scoring.
+        Signal 6: Fallback to the MLX LLM for classification with confidence scoring.
         """
         sender = (
             f"{email.sender_name} <{email.sender_address}>"
             if email.sender_name
             else email.sender_address or "Unknown"
         )
-        logger.debug(f"Using AI classification for email from {sender}")
+        logger.debug(f"Using MLX LLM classification for email from {sender}")
+
+        # Ensure MLX is initialized
+        if not self._init_mlx_components():
+            logger.warning("MLX LLM not available")
+            return "(Model Error)"
+
+        if self._mlx_llm is None:
+            logger.warning("MLX LLM not initialized")
+            return "(Model Error)"
 
         # Check cache first
         cache_key = self._get_cache_key(email)
@@ -231,9 +352,9 @@ class Classifier:
                 f"Sujet: {email.subject}\n"
                 f"De: {sender}\n"
                 f"Corps: {truncated_body}\n\n"
-                "Classe dans une des catégories suivantes (choisis la plus spécifique possible):\n"
+                "Classe dans une des catégories suivantes (la plus spécifique possible):\n"
                 f"{category_list}\n\n"
-                "Si aucune catégorie n'existe, tu peux proposer un nouveau sous-dossier au format 'Parent/NewSub'\n"
+                "Si aucune catégorie n'existe, propose un sous-dossier: 'Parent/NewSub'\n"
                 f"Parents valides: {', '.join(sorted(parent_folders))}\n\n"
                 "IMPORTANT: Réponds en format JSON structuré:\n"
                 "{\n"
@@ -241,7 +362,7 @@ class Classifier:
                 '  "confidence": 0.95,\n'
                 '  "reason": "brève explication (optionnel)"\n'
                 "}\n\n"
-                "- category: nom exact de la liste ci-dessus, ou 'Parent/NewSub' pour suggérer un nouveau sous-dossier\n"
+                "- category: nom exact ou 'Parent/NewSub' pour nouveau sous-dossier\n"
                 "- confidence: score entre 0.0 et 1.0 (0.0 = incertain, 1.0 = très confiant)\n"
                 "- reason: pourquoi cette catégorie (1 phrase courte, optionnel)\n\n"
                 "N'invente PAS de nouvelles catégories qui ne sont pas dans la liste."
@@ -269,47 +390,21 @@ class Classifier:
             )
 
         try:
-            # Prepare parameters based on model type
-            model_name = self.config.general.ollama_model
-            params = {
-                "model": model_name,
-                "messages": [{"role": "user", "content": prompt}],
-                "temperature": 0.2,
-            }
-
-            # Add provider-specific parameters
-            if model_name.startswith("ollama") or model_name.startswith("ollama_chat"):
-                # Ollama-specific parameters
-                params["api_base"] = self.config.general.api_base
-                params["extra_body"] = {
-                    "options": {
-                        "temperature": 0.2,
-                        "num_ctx": self.config.classifier.num_ctx,
-                    }
-                }
-            elif model_name.startswith("gemini"):
-                # Gemini doesn't need api_base or extra_body
-                # API key is read from GEMINI_API_KEY environment variable
-                pass
-
-            response = litellm.completion(**params)
-            raw_response = response.choices[0].message.content.strip()
-
-            # Try to parse JSON response first
-            category, confidence, reason = self._parse_ai_json_response(raw_response)
+            # Use MLX LLM classify method
+            category, confidence, reason = self._mlx_llm.classify(prompt)
 
             if category:
-                # Successfully parsed JSON response
                 logger.debug(
-                    f"AI classification (JSON): category='{category}', "
+                    f"MLX LLM classification: category='{category}', "
                     f"confidence={confidence:.2f}, reason='{reason}'"
                 )
 
                 # Check against confidence threshold
-                if confidence < self.config.classifier.ai_confidence_threshold:
+                confidence_threshold = self.config.mlx.llm_confidence
+                if confidence < confidence_threshold:
                     logger.info(
-                        f"AI confidence {confidence:.2f} below threshold "
-                        f"{self.config.classifier.ai_confidence_threshold:.2f}, routing to 'À Classer'"
+                        f"MLX LLM confidence {confidence:.2f} below threshold "
+                        f"{confidence_threshold:.2f}, routing to 'À Classer'"
                     )
                     self._log_proposal(email, f"{category} (confidence: {confidence:.2f}, reason: {reason})")
                     return "À Classer"
@@ -320,7 +415,7 @@ class Classifier:
                     if "/" in category and category not in self.categories:
                         parts = category.split("/", 1)
                         if len(parts) == 2:
-                            parent, subfolder = parts
+                            parent, _subfolder = parts
                             if self.folder_analyzer.is_valid_parent_folder(parent):
                                 logger.debug(f"Valid new folder proposal: '{category}'")
                                 self._log_proposal(
@@ -330,7 +425,7 @@ class Classifier:
 
                     # Check if category exists
                     if category not in self.categories:
-                        logger.warning(f"AI suggested invalid category: '{category}'")
+                        logger.warning(f"MLX LLM suggested invalid category: '{category}'")
                         self._log_proposal(
                             email, f"{category} (confidence: {confidence:.2f}, reason: {reason})"
                         )
@@ -338,7 +433,7 @@ class Classifier:
                 else:
                     # Static schema mode
                     if category not in self.categories:
-                        logger.warning(f"AI suggested invalid category: '{category}'")
+                        logger.warning(f"MLX LLM suggested invalid category: '{category}'")
                         self._log_proposal(
                             email, f"{category} (confidence: {confidence:.2f}, reason: {reason})"
                         )
@@ -349,30 +444,13 @@ class Classifier:
                 return category
 
             else:
-                # Fallback to legacy parsing
-                logger.debug(f"AI response not JSON format, using legacy parsing: {raw_response[:100]}")
-                category = self._parse_legacy_ai_response(raw_response)
-
-                if not category:
-                    # Empty category from legacy parser means uncertain/invalid
-                    self._log_proposal(email, raw_response)
-                    return "À Classer"
-
-                # Validate category
-                if category not in self.categories:
-                    self._log_proposal(email, category)
-                    return "À Classer"
-
-                # Cache and return
-                self.ai_cache[cache_key] = category
-                logger.debug(f"AI response (legacy): '{category}' (cached: False)")
-                return category
-
-            # Only log prompt in trace/debug mode for performance
-            logger.trace(f"AI prompt:\n{prompt}")
+                # Empty category means parsing failed or uncertain
+                logger.debug("MLX LLM returned empty category")
+                self._log_proposal(email, f"(empty response, confidence: {confidence:.2f})")
+                return "À Classer"
 
         except Exception as e:
-            logger.error(f"Error calling litellm: {e}")
+            logger.error(f"Error calling MLX LLM: {e}")
             return "(Model Error)"
 
     def classify_email(self, email: Email) -> str:
@@ -446,29 +524,42 @@ class Classifier:
             )
             return category
 
-        # Signal 5: AI Model (Fallback)
-        logger.debug("No high-confidence signals found, falling back to AI model.")
-        ai_start_time = time.perf_counter()
+        # Signal 5: Semantic Router (Embedding-based classification)
+        category, semantic_score = self._get_category_from_semantic_router(email)
+        if category:
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+            logger.info(f"Classified via Semantic Router: {category} (score: {semantic_score:.3f})")
+            self.database.update_suggestion(email.sender_address, category)
+            METRICS.classification_metrics.record_classification(
+                email_id=email.msg_id,
+                signal="semantic_router",
+                category=category,
+                confidence=semantic_score,
+                processing_time_ms=elapsed_ms,
+            )
+            return category
+
+        # Signal 6: MLX LLM (Fallback)
+        logger.debug("No high-confidence signals found, falling back to MLX LLM.")
         category = self._get_category_from_ai(email)
-        ai_elapsed_ms = (time.perf_counter() - ai_start_time) * 1000
         total_elapsed_ms = (time.perf_counter() - start_time) * 1000
 
-        logger.info(f"Classified via AI Model: {category}")
+        logger.info(f"Classified via MLX LLM: {category}")
 
         if category not in ["À Classer", "(Model Error)"]:
             self.database.update_suggestion(email.sender_address, category)
             METRICS.classification_metrics.record_classification(
                 email_id=email.msg_id,
-                signal="ai_model",
+                signal="mlx_llm",
                 category=category,
                 confidence=None,  # Confidence already tracked in _get_category_from_ai
                 processing_time_ms=total_elapsed_ms,
             )
         elif category == "(Model Error)":
-            METRICS.classification_metrics.record_error("ai_model_error", email.sender_address)
+            METRICS.classification_metrics.record_error("mlx_llm_error", email.sender_address)
         else:
             # "À Classer" - low confidence or uncertain
-            METRICS.classification_metrics.record_error("ai_uncertain", email.sender_address)
+            METRICS.classification_metrics.record_error("mlx_llm_uncertain", email.sender_address)
 
         return category
 

--- a/src/mailtag/classifier.py
+++ b/src/mailtag/classifier.py
@@ -223,14 +223,10 @@ class Classifier:
         if category:
             # Validate category exists in our known categories
             if category in self.categories:
-                logger.debug(
-                    f"Semantic router matched '{category}' with score {score:.3f}"
-                )
+                logger.debug(f"Semantic router matched '{category}' with score {score:.3f}")
                 return category, score
             else:
-                logger.debug(
-                    f"Semantic router suggested unknown category '{category}', ignoring"
-                )
+                logger.debug(f"Semantic router suggested unknown category '{category}', ignoring")
 
         return None, score
 
@@ -240,7 +236,7 @@ class Classifier:
         subject = email.subject or "No Subject"
         # Create a hash of sender + subject for caching
         cache_input = f"{sender.lower()}:{subject.lower()}"
-        return hashlib.md5(cache_input.encode()).hexdigest()
+        return hashlib.md5(cache_input.encode(), usedforsecurity=False).hexdigest()
 
     def _truncate_body(self, body: str, max_chars: int = 1500) -> str:
         """Intelligently truncate email body to preserve important content.

--- a/src/mailtag/config.py
+++ b/src/mailtag/config.py
@@ -59,6 +59,22 @@ class FastParseConfig:
 
 
 @dataclass
+class MLXConfig:
+    """Configuration for MLX-based classification (Apple Silicon optimized)."""
+
+    enabled: bool = True
+    # Semantic Router (Signal 5) - embedding-based classification
+    embedding_model: str = "nomic-ai/nomic-embed-text-v1.5"
+    score_threshold: float = 0.75
+    embeddings_file: str = "data/category_embeddings.npz"
+    # LLM Fallback (Signal 6) - text generation
+    llm_model: str = "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
+    llm_confidence: float = 0.85
+    llm_max_tokens: int = 256
+    llm_temperature: float = 0.2
+
+
+@dataclass
 class AppConfig:
     general: GeneralConfig
     logging: LoggingConfig
@@ -66,6 +82,7 @@ class AppConfig:
     imap: ImapConfig
     gmail: GmailConfig
     fast_parse: FastParseConfig
+    mlx: MLXConfig
 
 
 def load_config(path: Path) -> AppConfig:
@@ -109,6 +126,18 @@ def load_config(path: Path) -> AppConfig:
                 metrics_log_interval_minutes=fast_parse_data.get("metrics_log_interval_minutes", 10),
             )
 
+            mlx_data = data.get("mlx", {})
+            mlx_config = MLXConfig(
+                enabled=mlx_data.get("enabled", True),
+                embedding_model=mlx_data.get("embedding_model", "nomic-ai/nomic-embed-text-v1.5"),
+                score_threshold=mlx_data.get("score_threshold", 0.75),
+                embeddings_file=mlx_data.get("embeddings_file", "data/category_embeddings.npz"),
+                llm_model=mlx_data.get("llm_model", "mlx-community/Mistral-7B-Instruct-v0.3-4bit"),
+                llm_confidence=mlx_data.get("llm_confidence", 0.85),
+                llm_max_tokens=mlx_data.get("llm_max_tokens", 256),
+                llm_temperature=mlx_data.get("llm_temperature", 0.2),
+            )
+
             return AppConfig(
                 general=GeneralConfig(
                     ollama_model=ollama_model,
@@ -138,6 +167,7 @@ def load_config(path: Path) -> AppConfig:
                     token_file=data["gmail"]["token_file"],
                 ),
                 fast_parse=fast_parse_config,
+                mlx=mlx_config,
             )
     except (FileNotFoundError, KeyError, tomllib.TOMLDecodeError, ValueError) as e:
         raise RuntimeError(f"Failed to load or parse config file: {e}") from e
@@ -178,4 +208,5 @@ except RuntimeError as e:
             unclassified_folder_name="Unclassified",
             junk_folder_name="Junk",
         ),
+        mlx=MLXConfig(),
     )

--- a/src/mailtag/database.py
+++ b/src/mailtag/database.py
@@ -1,10 +1,29 @@
 import json
+import re
 from collections import defaultdict
 from pathlib import Path
 
 from loguru import logger
 
 from .utils.domain_utils import extract_domain, normalize_domain
+
+
+def _normalize_email(email: str) -> str:
+    """Normalize an email address for consistent storage.
+
+    - Strip angle brackets
+    - Convert to lowercase
+    - Strip whitespace
+    """
+    if not email:
+        return ""
+    # Strip angle brackets
+    email = re.sub(r"^<|>$", "", email.strip())
+    # Extract email from "Name <email>" format
+    match = re.search(r"<([^>]+)>", email)
+    if match:
+        email = match.group(1)
+    return email.lower().strip()
 
 
 class ClassificationDatabase:
@@ -65,33 +84,35 @@ class ClassificationDatabase:
 
     def update_suggestion(self, sender_address: str, category: str):
         """Updates the occurrence count for a sender-category pair in the suggestion database."""
-        self.suggestion_db[sender_address.lower()][category] += 1
+        normalized = _normalize_email(sender_address)
+        self.suggestion_db[normalized][category] += 1
         self._save_suggestion_db()
 
     def promote_to_validated(self, sender_address: str, category: str):
         """Promotes a classification from the suggestion DB to the validated DB."""
-        sender_address = sender_address.lower()
+        normalized = _normalize_email(sender_address)
         # Remove from suggestion DB
-        if sender_address in self.suggestion_db:
-            del self.suggestion_db[sender_address]
+        if normalized in self.suggestion_db:
+            del self.suggestion_db[normalized]
             self._save_suggestion_db()
         # Add to validated DB
-        self.validated_db[sender_address] = {category: 1}
+        self.validated_db[normalized] = {category: 1}
         self._save_validated_db()
 
     def get_classification_count(self, sender_address: str, category: str) -> int:
         """Gets the classification count for a sender-category pair from the suggestion DB."""
-        return self.suggestion_db[sender_address.lower()][category]
+        normalized = _normalize_email(sender_address)
+        return self.suggestion_db[normalized][category]
 
     def get_dominant_classification(self, sender_address: str) -> str | None:
         """Gets the category with the highest count for a given sender."""
-        sender_address = sender_address.lower()
+        normalized = _normalize_email(sender_address)
         # Check validated DB first
-        if sender_address in self.validated_db:
-            return list(self.validated_db[sender_address].keys())[0]
+        if normalized in self.validated_db:
+            return list(self.validated_db[normalized].keys())[0]
         # Then check suggestion DB
-        if sender_address in self.suggestion_db:
-            classifications = self.suggestion_db[sender_address]
+        if normalized in self.suggestion_db:
+            classifications = self.suggestion_db[normalized]
             if classifications:
                 return max(classifications, key=classifications.get)
         return None

--- a/src/mailtag/filter_generator.py
+++ b/src/mailtag/filter_generator.py
@@ -31,7 +31,6 @@ class FilterGenerator:
         sender_categories.sort(key=lambda x: x[0])
 
         for most_common_category, sender in sender_categories:
-
             entry = SubElement(feed, "entry")
             SubElement(entry, "category", term="filter")
             title = SubElement(entry, "title")
@@ -76,7 +75,7 @@ class FilterGenerator:
 
         # Pretty print the XML
         xml_str = tostring(feed, "utf-8")
-        pretty_xml_str = minidom.parseString(xml_str).toprettyxml(indent="    ")
+        pretty_xml_str = minidom.parseString(xml_str).toprettyxml(indent="    ")  # nosec B318
 
         with self.output_path.open("w", encoding="utf-8") as f:
             f.write(pretty_xml_str)

--- a/src/mailtag/filter_generator.py
+++ b/src/mailtag/filter_generator.py
@@ -1,77 +1,190 @@
+from collections import defaultdict
 from pathlib import Path
 from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement, register_namespace, tostring
 
+from loguru import logger
+
 from .database import ClassificationDatabase
+from .utils.domain_utils import extract_domain, is_non_commercial_domain_cached
 
 
 class FilterGenerator:
-    """Generates a Gmail filter XML file from the classification database."""
+    """Generates a Gmail filter XML file from the classification database.
 
-    def __init__(self, database: ClassificationDatabase, output_path: Path):
+    Supports domain consolidation to reduce filter count by using wildcard
+    patterns like *@domain.com for commercial domains with multiple senders.
+    """
+
+    def __init__(
+        self,
+        database: ClassificationDatabase,
+        output_path: Path,
+        consolidate_domains: bool = True,
+        consolidation_threshold: int = 2,
+    ):
+        """Initialize the filter generator.
+
+        Args:
+            database: The classification database to generate filters from.
+            output_path: Path to write the mailfilter.xml file.
+            consolidate_domains: If True, consolidate multiple senders from same
+                commercial domain into a single wildcard filter.
+            consolidation_threshold: Minimum number of senders from a domain
+                before consolidating (default: 2).
+        """
         self.database = database
         self.output_path = output_path
+        self.consolidate_domains = consolidate_domains
+        self.consolidation_threshold = consolidation_threshold
         register_namespace("apps", "http://schemas.google.com/apps/2006")
 
-    def generate_filters(self):
-        """Generates the mailfilter.xml file."""
-        feed = Element("feed", xmlns="http://www.w3.org/2005/Atom")
+    def _collect_sender_categories(self) -> list[tuple[str, str]]:
+        """Collect all unique senders and their dominant categories.
 
-        # Collect all unique senders from both suggestion and validated databases
+        Returns:
+            List of (category, sender) tuples.
+        """
         all_senders = set(self.database.suggestion_db.keys()).union(self.database.validated_db.keys())
 
-        # Collect all unique senders and their dominant categories
         sender_categories = []
         for sender in all_senders:
             most_common_category = self.database.get_dominant_classification(sender)
             if most_common_category:
                 sender_categories.append((most_common_category, sender))
 
-        # Sort by category (label)
-        sender_categories.sort(key=lambda x: x[0])
+        return sender_categories
 
-        for most_common_category, sender in sender_categories:
-            entry = SubElement(feed, "entry")
-            SubElement(entry, "category", term="filter")
-            title = SubElement(entry, "title")
-            title.text = f"MailTag - {most_common_category}"
+    def _consolidate_by_domain(self, sender_categories: list[tuple[str, str]]) -> list[tuple[str, str]]:
+        """Consolidate senders by domain where appropriate.
 
-            SubElement(
-                entry,
-                "{http://schemas.google.com/apps/2006}property",
-                name="from",
-                value=sender,
+        Groups senders by (domain, category) and replaces groups with wildcard
+        patterns for commercial domains that meet the threshold.
+
+        Args:
+            sender_categories: List of (category, sender) tuples.
+
+        Returns:
+            Consolidated list of (category, filter_value) tuples.
+        """
+        # Group by (domain, category)
+        domain_groups: dict[tuple[str, str], list[str]] = defaultdict(list)
+        individual_entries: list[tuple[str, str]] = []
+
+        for category, sender in sender_categories:
+            domain = extract_domain(sender)
+
+            if not domain:
+                # No domain extracted, keep as individual entry
+                individual_entries.append((category, sender))
+                continue
+
+            if is_non_commercial_domain_cached(domain):
+                # Non-commercial domains (gmail, hotmail, etc.) should not be
+                # consolidated as they represent different individuals
+                individual_entries.append((category, sender))
+                continue
+
+            domain_groups[(domain, category)].append(sender)
+
+        # Process domain groups
+        consolidated_entries: list[tuple[str, str]] = []
+        consolidated_count = 0
+        original_count = 0
+
+        for (domain, category), senders in domain_groups.items():
+            original_count += len(senders)
+
+            if len(senders) >= self.consolidation_threshold:
+                # Consolidate to wildcard pattern
+                wildcard = f"*@{domain}"
+                consolidated_entries.append((category, wildcard))
+                consolidated_count += 1
+                logger.debug(
+                    f"Consolidated {len(senders)} senders from @{domain} "
+                    f"into wildcard filter for '{category}'"
+                )
+            else:
+                # Keep individual entries
+                for sender in senders:
+                    consolidated_entries.append((category, sender))
+
+        # Combine all entries
+        all_entries = individual_entries + consolidated_entries
+
+        # Log consolidation stats
+        individual_count = len(individual_entries)
+        final_count = len(all_entries)
+        if consolidated_count > 0:
+            logger.info(
+                f"Domain consolidation: {original_count + individual_count} -> "
+                f"{final_count} filters ({consolidated_count} wildcard patterns created)"
             )
-            SubElement(
-                entry,
-                "{http://schemas.google.com/apps/2006}property",
-                name="label",
-                value=most_common_category,
-            )
-            SubElement(
-                entry,
-                "{http://schemas.google.com/apps/2006}property",
-                name="shouldArchive",
-                value="true",
-            )
-            SubElement(
-                entry,
-                "{http://schemas.google.com/apps/2006}property",
-                name="shouldMarkAsRead",
-                value="true",
-            )
-            SubElement(
-                entry,
-                "{http://schemas.google.com/apps/2006}property",
-                name="shouldNeverSpam",
-                value="true",
-            )
-            SubElement(
-                entry,
-                "{http://schemas.google.com/apps/2006}property",
-                name="hasTheWord",
-                value="has:unread",
-            )
+
+        return all_entries
+
+    def _create_filter_entry(self, feed: Element, category: str, filter_value: str) -> None:
+        """Create a single filter entry in the XML feed.
+
+        Args:
+            feed: The XML feed element to add the entry to.
+            category: The label/category for the filter.
+            filter_value: The from value (email or wildcard pattern).
+        """
+        entry = SubElement(feed, "entry")
+        SubElement(entry, "category", term="filter")
+        title = SubElement(entry, "title")
+        title.text = f"MailTag - {category}"
+
+        SubElement(
+            entry,
+            "{http://schemas.google.com/apps/2006}property",
+            name="from",
+            value=filter_value,
+        )
+        SubElement(
+            entry,
+            "{http://schemas.google.com/apps/2006}property",
+            name="label",
+            value=category,
+        )
+        SubElement(
+            entry,
+            "{http://schemas.google.com/apps/2006}property",
+            name="shouldArchive",
+            value="true",
+        )
+        SubElement(
+            entry,
+            "{http://schemas.google.com/apps/2006}property",
+            name="shouldNeverSpam",
+            value="true",
+        )
+
+    def generate_filters(self) -> int:
+        """Generates the mailfilter.xml file.
+
+        Returns:
+            Number of filter entries generated.
+        """
+        feed = Element("feed", xmlns="http://www.w3.org/2005/Atom")
+
+        # Collect sender categories
+        sender_categories = self._collect_sender_categories()
+        original_count = len(sender_categories)
+
+        # Apply domain consolidation if enabled
+        if self.consolidate_domains:
+            filter_entries = self._consolidate_by_domain(sender_categories)
+        else:
+            filter_entries = sender_categories
+
+        # Sort by category (label) for consistent output
+        filter_entries.sort(key=lambda x: x[0])
+
+        # Create XML entries
+        for category, filter_value in filter_entries:
+            self._create_filter_entry(feed, category, filter_value)
 
         # Pretty print the XML
         xml_str = tostring(feed, "utf-8")
@@ -79,3 +192,11 @@ class FilterGenerator:
 
         with self.output_path.open("w", encoding="utf-8") as f:
             f.write(pretty_xml_str)
+
+        final_count = len(filter_entries)
+        logger.info(
+            f"Generated {final_count} Gmail filters "
+            f"(from {original_count} sender entries) -> {self.output_path}"
+        )
+
+        return final_count

--- a/src/mailtag/gmail_auth.py
+++ b/src/mailtag/gmail_auth.py
@@ -3,11 +3,14 @@ import os
 
 from loguru import logger
 
+_GOOGLE_IMPORT_ERROR: ModuleNotFoundError | None = None
+
 try:  # pragma: no cover - import guarded for optional dependency
     from google.auth.transport.requests import Request
     from google.oauth2.credentials import Credentials
     from google_auth_oauthlib.flow import InstalledAppFlow
     from googleapiclient.discovery import build
+
     GOOGLE_DEPS_AVAILABLE = True
 except ModuleNotFoundError as e:  # pragma: no cover - exercised via tests
     GOOGLE_DEPS_AVAILABLE = False

--- a/src/mailtag/mlx_provider.py
+++ b/src/mailtag/mlx_provider.py
@@ -165,6 +165,7 @@ class MLXLLM:
             Generated text response
         """
         from mlx_lm import generate
+        from mlx_lm.sample_utils import make_sampler
 
         max_tokens = max_tokens or self.max_tokens
         temperature = temperature or self.temperature
@@ -178,12 +179,15 @@ class MLXLLM:
         else:
             formatted_prompt = prompt
 
+        # Create sampler with temperature (new API)
+        sampler = make_sampler(temp=temperature)
+
         response = generate(
             self.model,
             self.tokenizer,
             prompt=formatted_prompt,
             max_tokens=max_tokens,
-            temp=temperature,
+            sampler=sampler,
             verbose=False,
         )
 

--- a/src/mailtag/mlx_provider.py
+++ b/src/mailtag/mlx_provider.py
@@ -1,0 +1,258 @@
+"""MLX-based AI providers for Apple Silicon optimized classification.
+
+This module provides two main classes:
+- MLXEmbedder: Generates text embeddings using sentence-transformers
+- MLXLLM: Generates text using mlx-lm for classification fallback
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from loguru import logger
+
+if TYPE_CHECKING:
+    from sentence_transformers import SentenceTransformer
+
+
+class MLXEmbedder:
+    """Generates embeddings using sentence-transformers with MLX backend.
+
+    Supports models like nomic-ai/nomic-embed-text-v1.5 which are optimized
+    for semantic similarity tasks and support long context (8k tokens).
+    """
+
+    def __init__(self, model_name: str = "nomic-ai/nomic-embed-text-v1.5"):
+        """Initialize the embedder with the specified model.
+
+        Args:
+            model_name: HuggingFace model name for embeddings
+        """
+        self.model_name = model_name
+        self._model: SentenceTransformer | None = None
+        logger.info(f"MLXEmbedder initialized with model: {model_name}")
+
+    @property
+    def model(self) -> SentenceTransformer:
+        """Lazy load the embedding model."""
+        if self._model is None:
+            logger.info(f"Loading embedding model: {self.model_name}")
+            from sentence_transformers import SentenceTransformer
+
+            self._model = SentenceTransformer(self.model_name, trust_remote_code=True)
+            logger.info("Embedding model loaded successfully")
+        return self._model
+
+    def encode(self, texts: list[str] | str, prefix: str = "search_document: ") -> np.ndarray:
+        """Generate embeddings for the given texts.
+
+        Args:
+            texts: Single text or list of texts to encode
+            prefix: Prefix to add to each text (nomic models use task prefixes)
+
+        Returns:
+            Numpy array of embeddings with shape (n_texts, embedding_dim)
+        """
+        if isinstance(texts, str):
+            texts = [texts]
+
+        # Add prefix for nomic models (they use task-specific prefixes)
+        if "nomic" in self.model_name.lower():
+            texts = [f"{prefix}{text}" for text in texts]
+
+        embeddings = self.model.encode(texts, convert_to_numpy=True)
+        return embeddings
+
+    def encode_query(self, query: str) -> np.ndarray:
+        """Encode a query text (for searching against documents).
+
+        Args:
+            query: The query text to encode
+
+        Returns:
+            Numpy array of shape (embedding_dim,)
+        """
+        return self.encode(query, prefix="search_query: ")[0]
+
+    def encode_documents(self, documents: list[str]) -> np.ndarray:
+        """Encode document texts (for building an index).
+
+        Args:
+            documents: List of document texts to encode
+
+        Returns:
+            Numpy array of shape (n_documents, embedding_dim)
+        """
+        return self.encode(documents, prefix="search_document: ")
+
+    def similarity(self, query_embedding: np.ndarray, doc_embeddings: np.ndarray) -> np.ndarray:
+        """Compute cosine similarity between query and document embeddings.
+
+        Args:
+            query_embedding: Query embedding of shape (embedding_dim,)
+            doc_embeddings: Document embeddings of shape (n_docs, embedding_dim)
+
+        Returns:
+            Similarity scores of shape (n_docs,)
+        """
+        # Normalize embeddings
+        query_norm = query_embedding / np.linalg.norm(query_embedding)
+        doc_norms = doc_embeddings / np.linalg.norm(doc_embeddings, axis=1, keepdims=True)
+
+        # Compute cosine similarity
+        similarities = np.dot(doc_norms, query_norm)
+        return similarities
+
+
+class MLXLLM:
+    """Generates text using mlx-lm for classification fallback.
+
+    Uses quantized models from mlx-community for efficient inference
+    on Apple Silicon.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "mlx-community/Mistral-7B-Instruct-v0.3-4bit",
+        max_tokens: int = 256,
+        temperature: float = 0.2,
+    ):
+        """Initialize the LLM with the specified model.
+
+        Args:
+            model_name: MLX model name from mlx-community
+            max_tokens: Maximum tokens to generate
+            temperature: Sampling temperature (lower = more deterministic)
+        """
+        self.model_name = model_name
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self._model = None
+        self._tokenizer = None
+        logger.info(f"MLXLLM initialized with model: {model_name}")
+
+    def _load_model(self):
+        """Lazy load the model and tokenizer."""
+        if self._model is None:
+            logger.info(f"Loading LLM model: {self.model_name}")
+            from mlx_lm import load
+
+            self._model, self._tokenizer = load(self.model_name)
+            logger.info("LLM model loaded successfully")
+
+    @property
+    def model(self):
+        """Get the loaded model."""
+        self._load_model()
+        return self._model
+
+    @property
+    def tokenizer(self):
+        """Get the loaded tokenizer."""
+        self._load_model()
+        return self._tokenizer
+
+    def generate(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None) -> str:
+        """Generate text completion for the given prompt.
+
+        Args:
+            prompt: The input prompt
+            max_tokens: Override default max tokens
+            temperature: Override default temperature
+
+        Returns:
+            Generated text response
+        """
+        from mlx_lm import generate
+
+        max_tokens = max_tokens or self.max_tokens
+        temperature = temperature or self.temperature
+
+        # Apply chat template if available
+        if hasattr(self.tokenizer, "apply_chat_template"):
+            messages = [{"role": "user", "content": prompt}]
+            formatted_prompt = self.tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        else:
+            formatted_prompt = prompt
+
+        response = generate(
+            self.model,
+            self.tokenizer,
+            prompt=formatted_prompt,
+            max_tokens=max_tokens,
+            temp=temperature,
+            verbose=False,
+        )
+
+        return response.strip()
+
+    def classify(self, prompt: str) -> tuple[str, float, str]:
+        """Generate a classification response and parse it.
+
+        Args:
+            prompt: The classification prompt (should request JSON output)
+
+        Returns:
+            Tuple of (category, confidence, reason)
+        """
+        import json
+        import re
+
+        response = self.generate(prompt)
+
+        # Try to parse JSON response
+        json_match = re.search(r"\{[^}]+\}", response, re.DOTALL)
+        if json_match:
+            try:
+                result = json.loads(json_match.group(0))
+                category = result.get("category", "").strip()
+                confidence = float(result.get("confidence", 0.0))
+                reason = result.get("reason", "")
+
+                # Validate confidence range
+                confidence = max(0.0, min(1.0, confidence))
+
+                return category, confidence, reason
+            except (json.JSONDecodeError, ValueError, KeyError):
+                pass
+
+        # Fallback: return raw response as category with low confidence
+        logger.warning(f"Failed to parse JSON from LLM response: {response[:100]}...")
+        return response.strip(), 0.5, "JSON parsing failed"
+
+
+def get_embedder(model_name: str | None = None) -> MLXEmbedder:
+    """Factory function to get an MLXEmbedder instance.
+
+    Args:
+        model_name: Optional model name override
+
+    Returns:
+        MLXEmbedder instance
+    """
+    if model_name:
+        return MLXEmbedder(model_name)
+    return MLXEmbedder()
+
+
+def get_llm(
+    model_name: str | None = None,
+    max_tokens: int = 256,
+    temperature: float = 0.2,
+) -> MLXLLM:
+    """Factory function to get an MLXLLM instance.
+
+    Args:
+        model_name: Optional model name override
+        max_tokens: Maximum tokens to generate
+        temperature: Sampling temperature
+
+    Returns:
+        MLXLLM instance
+    """
+    if model_name:
+        return MLXLLM(model_name, max_tokens, temperature)
+    return MLXLLM(max_tokens=max_tokens, temperature=temperature)

--- a/src/mailtag/semantic_router.py
+++ b/src/mailtag/semantic_router.py
@@ -1,0 +1,266 @@
+"""Semantic Router for embedding-based email classification.
+
+This module provides fast, embedding-based classification that routes
+emails to categories based on semantic similarity, without requiring
+LLM inference.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from loguru import logger
+
+if TYPE_CHECKING:
+    from mailtag.mlx_provider import MLXEmbedder
+
+
+class SemanticRouter:
+    """Routes text to categories based on embedding similarity.
+
+    Uses pre-computed category embeddings to instantly classify
+    emails based on semantic similarity to category centroids.
+    """
+
+    def __init__(
+        self,
+        embedder: MLXEmbedder,
+        score_threshold: float = 0.75,
+    ):
+        """Initialize the semantic router.
+
+        Args:
+            embedder: MLXEmbedder instance for generating embeddings
+            score_threshold: Minimum similarity score to accept a route (0.0-1.0)
+        """
+        self.embedder = embedder
+        self.score_threshold = score_threshold
+        self.category_embeddings: dict[str, np.ndarray] = {}
+        self.categories: list[str] = []
+        self._embedding_matrix: np.ndarray | None = None
+        logger.info(f"SemanticRouter initialized with threshold: {score_threshold}")
+
+    def load_embeddings(self, path: Path | str) -> bool:
+        """Load pre-computed category embeddings from file.
+
+        Args:
+            path: Path to the .npz file containing embeddings
+
+        Returns:
+            True if loaded successfully, False otherwise
+        """
+        path = Path(path)
+        if not path.exists():
+            logger.warning(f"Embeddings file not found: {path}")
+            return False
+
+        try:
+            data = np.load(path, allow_pickle=True)
+            self.category_embeddings = {key: data[key] for key in data.files}
+            self.categories = list(self.category_embeddings.keys())
+            self._build_embedding_matrix()
+            logger.info(f"Loaded embeddings for {len(self.categories)} categories from {path}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to load embeddings from {path}: {e}")
+            return False
+
+    def save_embeddings(self, path: Path | str) -> bool:
+        """Save category embeddings to file.
+
+        Args:
+            path: Path to save the .npz file
+
+        Returns:
+            True if saved successfully, False otherwise
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            np.savez(path, **self.category_embeddings)
+            logger.info(f"Saved embeddings for {len(self.categories)} categories to {path}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save embeddings to {path}: {e}")
+            return False
+
+    def _build_embedding_matrix(self):
+        """Build the embedding matrix for efficient similarity computation."""
+        if not self.category_embeddings:
+            self._embedding_matrix = None
+            return
+
+        self._embedding_matrix = np.stack([self.category_embeddings[cat] for cat in self.categories])
+        # Normalize for cosine similarity
+        norms = np.linalg.norm(self._embedding_matrix, axis=1, keepdims=True)
+        self._embedding_matrix = self._embedding_matrix / norms
+
+    def build_from_examples(self, category_examples: dict[str, list[str]]) -> None:
+        """Build category embeddings from example texts.
+
+        Args:
+            category_examples: Dict mapping category names to lists of example texts
+        """
+        logger.info(f"Building embeddings for {len(category_examples)} categories...")
+
+        for category, examples in category_examples.items():
+            if not examples:
+                logger.warning(f"No examples for category '{category}', skipping")
+                continue
+
+            # Compute embeddings for all examples
+            embeddings = self.embedder.encode_documents(examples)
+
+            # Use centroid (mean) as category embedding
+            centroid = embeddings.mean(axis=0)
+            self.category_embeddings[category] = centroid
+
+            logger.debug(f"Built embedding for '{category}' from {len(examples)} examples")
+
+        self.categories = list(self.category_embeddings.keys())
+        self._build_embedding_matrix()
+        logger.info(f"Built embeddings for {len(self.categories)} categories")
+
+    def build_from_validated_db(self, validated_db: dict[str, str], min_examples: int = 1) -> None:
+        """Build category embeddings from validated classification database.
+
+        Args:
+            validated_db: Dict mapping sender email to category
+            min_examples: Minimum examples required per category
+        """
+        # Group by category
+        category_senders: dict[str, list[str]] = {}
+        for sender, category in validated_db.items():
+            if category not in category_senders:
+                category_senders[category] = []
+            category_senders[category].append(sender)
+
+        # Build examples from sender addresses
+        category_examples: dict[str, list[str]] = {}
+        for category, senders in category_senders.items():
+            if len(senders) >= min_examples:
+                # Use sender domain and category name as examples
+                examples = []
+                for sender in senders[:10]:  # Limit to 10 examples per category
+                    # Create representative text from sender
+                    domain = sender.split("@")[-1] if "@" in sender else sender
+                    examples.append(f"Email from {domain} categorized as {category}")
+                category_examples[category] = examples
+
+        self.build_from_examples(category_examples)
+
+    def route(self, text: str) -> tuple[str, float]:
+        """Route text to the most similar category.
+
+        Args:
+            text: Input text to classify
+
+        Returns:
+            Tuple of (category, similarity_score)
+            Returns ("", 0.0) if no category meets threshold
+        """
+        if not self.categories or self._embedding_matrix is None:
+            logger.warning("No category embeddings loaded, cannot route")
+            return "", 0.0
+
+        # Compute query embedding
+        query_embedding = self.embedder.encode_query(text)
+        query_norm = query_embedding / np.linalg.norm(query_embedding)
+
+        # Compute similarities with all categories
+        similarities = np.dot(self._embedding_matrix, query_norm)
+
+        # Find best match
+        best_idx = np.argmax(similarities)
+        best_score = similarities[best_idx]
+        best_category = self.categories[best_idx]
+
+        if best_score >= self.score_threshold:
+            logger.debug(f"Routed to '{best_category}' with score {best_score:.3f}")
+            return best_category, float(best_score)
+        else:
+            logger.debug(f"No route found (best: '{best_category}' with score {best_score:.3f})")
+            return "", float(best_score)
+
+    def route_with_alternatives(self, text: str, top_k: int = 3) -> list[tuple[str, float]]:
+        """Route text and return top-k alternatives.
+
+        Args:
+            text: Input text to classify
+            top_k: Number of top alternatives to return
+
+        Returns:
+            List of (category, score) tuples sorted by score descending
+        """
+        if not self.categories or self._embedding_matrix is None:
+            return []
+
+        query_embedding = self.embedder.encode_query(text)
+        query_norm = query_embedding / np.linalg.norm(query_embedding)
+        similarities = np.dot(self._embedding_matrix, query_norm)
+
+        # Get top-k indices
+        top_indices = np.argsort(similarities)[-top_k:][::-1]
+
+        results = []
+        for idx in top_indices:
+            results.append((self.categories[idx], float(similarities[idx])))
+
+        return results
+
+    def add_category(self, category: str, examples: list[str]) -> None:
+        """Add a new category with examples.
+
+        Args:
+            category: Category name
+            examples: List of example texts
+        """
+        if not examples:
+            logger.warning(f"No examples provided for category '{category}'")
+            return
+
+        embeddings = self.embedder.encode_documents(examples)
+        centroid = embeddings.mean(axis=0)
+        self.category_embeddings[category] = centroid
+
+        if category not in self.categories:
+            self.categories.append(category)
+
+        self._build_embedding_matrix()
+        logger.info(f"Added category '{category}' with {len(examples)} examples")
+
+    def remove_category(self, category: str) -> bool:
+        """Remove a category.
+
+        Args:
+            category: Category name to remove
+
+        Returns:
+            True if removed, False if not found
+        """
+        if category not in self.category_embeddings:
+            return False
+
+        del self.category_embeddings[category]
+        self.categories.remove(category)
+        self._build_embedding_matrix()
+        logger.info(f"Removed category '{category}'")
+        return True
+
+    @property
+    def num_categories(self) -> int:
+        """Return the number of loaded categories."""
+        return len(self.categories)
+
+    def get_category_info(self) -> dict[str, dict]:
+        """Get information about loaded categories.
+
+        Returns:
+            Dict with category names and embedding dimensions
+        """
+        return {
+            cat: {"embedding_dim": emb.shape[0]} for cat, emb in self.category_embeddings.items()
+        }

--- a/src/mailtag/semantic_router.py
+++ b/src/mailtag/semantic_router.py
@@ -261,6 +261,4 @@ class SemanticRouter:
         Returns:
             Dict with category names and embedding dimensions
         """
-        return {
-            cat: {"embedding_dim": emb.shape[0]} for cat, emb in self.category_embeddings.items()
-        }
+        return {cat: {"embedding_dim": emb.shape[0]} for cat, emb in self.category_embeddings.items()}

--- a/src/mailtag/utils/CLAUDE.md
+++ b/src/mailtag/utils/CLAUDE.md
@@ -54,7 +54,59 @@ Analyze Pass 3 output files to find domain candidates for DB expansion.
 python src/main.py analyze-domains --output data/domain_candidates.json
 ```
 
+### data_cleanup.py
+Utilities for cleaning up accumulated data files.
+
+**Key Functions:**
+- `cleanup_old_pass3_files(data_dir, max_age_days)` - Remove pass3 files older than threshold
+- `consolidate_duplicate_pass3_files(data_dir)` - Remove duplicates, keep first/last per day
+- `get_pass3_file_stats(data_dir)` - Get statistics about pass3 files
+
+**Usage:**
+```bash
+python src/main.py cleanup --max-age 30
+python src/main.py cleanup --consolidate
+```
+
+### db_backup.py
+Database backup and restore utilities with automatic rotation.
+
+**Key Functions:**
+- `backup_database(db_path, backup_dir)` - Create timestamped backup
+- `backup_all_databases(db_dir)` - Backup all JSON databases
+- `restore_database(backup_path, db_path)` - Restore from backup
+- `cleanup_old_backups(backup_dir, keep_count)` - Remove old backups
+- `list_backups(backup_dir)` - List available backups
+- `get_backup_stats(backup_dir)` - Get backup statistics
+
+**Automatic Backups:**
+- Databases are backed up once at start of each classification run
+- Backups stored in `db/backups/` with timestamp suffix
+- Keeps 10 most recent backups by default
+
+### data_validation.py
+Validation and normalization utilities for data integrity.
+
+**Key Functions:**
+- `normalize_email(email)` - Strip brackets, decode RFC 2047, lowercase
+- `normalize_domain(domain)` - Strip artifacts, lowercase
+- `validate_domain_format(domain)` - Check valid domain pattern
+- `validate_domain_classifications(db_path)` - Find issues in domain DB
+- `validate_sender_classifications(db_path)` - Find issues in sender DB
+- `fix_domain_classifications(db_path)` - Auto-fix malformed domains
+- `prune_low_confidence_senders(db_path, min_count)` - Remove low-count entries
+- `get_database_stats(db_dir)` - Get statistics for all databases
+
+**Usage:**
+```bash
+python src/main.py db-stats
+python src/main.py prune-db --min-count 3
+```
+
 ## Testing
 Test files in `tests/`:
 - `test_text_utils.py`
 - `test_domain_analyzer.py`
+- `test_data_cleanup.py`
+- `test_db_backup.py`
+- `test_data_validation.py`

--- a/src/mailtag/utils/CLAUDE.md
+++ b/src/mailtag/utils/CLAUDE.md
@@ -1,0 +1,60 @@
+# src/mailtag/utils/
+
+Utility modules for domain handling, text processing, and task orchestration.
+
+## Modules
+
+### domain_utils.py
+Domain extraction and validation utilities with caching.
+
+**Key Functions:**
+- `extract_domain(email)` - Extract domain from email address
+- `normalize_domain(domain)` - Lowercase and clean domain
+- `is_valid_domain(domain)` - Validate domain format
+- `is_non_commercial_domain(domain)` - Check if gmail.com, yahoo.com, etc.
+- `is_non_commercial_domain_cached(domain)` - Cached version for performance
+- `load_non_commercial_domains()` - Load from `data/non_commercial_domains.txt`
+
+**Caching:**
+- Uses module-level `_non_commercial_cache` set
+- `_cache_loaded` flag prevents redundant file reads
+
+### text_utils.py
+Email body processing and analysis.
+
+**Key Functions:**
+- `smart_truncate(text, max_chars)` - Intelligent truncation preserving keywords
+- `_remove_signatures(text)` - Strip email signatures
+- `extract_urls(text)` - Find all URLs in text
+- `count_links(text)` - Count hyperlinks
+- `has_unsubscribe_link(text)` - Detect newsletter patterns
+- `extract_subject_keywords(subject)` - Pull key terms from subject
+- `is_likely_automated(email)` - Detect automated/transactional emails
+- `clean_whitespace(text)` - Normalize spacing
+
+### tasks.py
+Three-pass classification orchestration for IMAP.
+
+**Key Functions:**
+- `run_classification(provider, classifier, db, config)` - Main orchestrator
+- `_run_fast_parse_on_folder(...)` - Pass 1: Headers-only classification
+- `_run_domain_classification_pass(...)` - Pass 2: Domain-based bulk classification
+- `_dump_pass3_emails_for_manual_matching(...)` - Generate review files
+
+**Pass Flow:**
+1. Pass 1 uses validated/historical DBs on headers only
+2. Pass 2 groups by commercial domain, applies domain rules
+3. Pass 3 fetches full bodies, uses AI classification
+
+### domain_analyzer.py
+Analyze Pass 3 output files to find domain candidates for DB expansion.
+
+**Usage:**
+```bash
+python src/main.py analyze-domains --output data/domain_candidates.json
+```
+
+## Testing
+Test files in `tests/`:
+- `test_text_utils.py`
+- `test_domain_analyzer.py`

--- a/src/mailtag/utils/data_cleanup.py
+++ b/src/mailtag/utils/data_cleanup.py
@@ -1,0 +1,131 @@
+"""Utilities for cleaning up data files."""
+
+import re
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from loguru import logger
+
+
+def cleanup_old_pass3_files(data_dir: Path, max_age_days: int = 30) -> int:
+    """
+    Remove pass3_manual_matching files older than max_age_days.
+
+    Args:
+        data_dir: Path to the data directory
+        max_age_days: Maximum age in days for files to keep
+
+    Returns:
+        Number of files deleted
+    """
+    cutoff_date = datetime.now() - timedelta(days=max_age_days)
+    pattern = re.compile(r"pass3_manual_matching_(\d{8})_\d{6}\.json")
+    deleted_count = 0
+
+    for file_path in data_dir.glob("pass3_manual_matching_*.json"):
+        match = pattern.match(file_path.name)
+        if match:
+            date_str = match.group(1)
+            try:
+                file_date = datetime.strptime(date_str, "%Y%m%d")
+                if file_date < cutoff_date:
+                    file_path.unlink()
+                    logger.info(f"Deleted old pass3 file: {file_path.name}")
+                    deleted_count += 1
+            except ValueError:
+                logger.warning(f"Could not parse date from filename: {file_path.name}")
+
+    logger.info(f"Cleanup complete: deleted {deleted_count} pass3 files older than {max_age_days} days")
+    return deleted_count
+
+
+def consolidate_duplicate_pass3_files(data_dir: Path) -> int:
+    """
+    Remove duplicate pass3 files, keeping first and last of each day.
+
+    Args:
+        data_dir: Path to the data directory
+
+    Returns:
+        Number of files deleted
+    """
+    pattern = re.compile(r"pass3_manual_matching_(\d{8})_(\d{6})\.json")
+
+    # Group files by date
+    files_by_date: dict[str, list[tuple[str, Path]]] = defaultdict(list)
+
+    for file_path in data_dir.glob("pass3_manual_matching_*.json"):
+        match = pattern.match(file_path.name)
+        if match:
+            date_str = match.group(1)
+            time_str = match.group(2)
+            files_by_date[date_str].append((time_str, file_path))
+
+    deleted_count = 0
+
+    for date_str, files in files_by_date.items():
+        if len(files) <= 2:
+            continue  # Keep all if 2 or fewer files for this date
+
+        # Sort by time
+        files.sort(key=lambda x: x[0])
+
+        # Keep first and last, delete the rest
+        first_file = files[0][1]
+        last_file = files[-1][1]
+
+        for _time_str, file_path in files[1:-1]:
+            file_path.unlink()
+            logger.info(f"Deleted duplicate pass3 file: {file_path.name}")
+            deleted_count += 1
+
+        logger.debug(f"Date {date_str}: kept {first_file.name} and {last_file.name}")
+
+    logger.info(f"Consolidation complete: deleted {deleted_count} duplicate pass3 files")
+    return deleted_count
+
+
+def get_pass3_file_stats(data_dir: Path) -> dict:
+    """
+    Get statistics about pass3 files.
+
+    Args:
+        data_dir: Path to the data directory
+
+    Returns:
+        Dictionary with statistics
+    """
+    pattern = re.compile(r"pass3_manual_matching_(\d{8})_\d{6}\.json")
+    files = list(data_dir.glob("pass3_manual_matching_*.json"))
+
+    if not files:
+        return {
+            "total_files": 0,
+            "total_size_bytes": 0,
+            "oldest_date": None,
+            "newest_date": None,
+            "files_by_date": {},
+        }
+
+    total_size = sum(f.stat().st_size for f in files)
+    dates: list[str] = []
+    files_by_date: dict[str, int] = defaultdict(int)
+
+    for file_path in files:
+        match = pattern.match(file_path.name)
+        if match:
+            date_str = match.group(1)
+            dates.append(date_str)
+            files_by_date[date_str] += 1
+
+    dates.sort()
+
+    return {
+        "total_files": len(files),
+        "total_size_bytes": total_size,
+        "total_size_mb": round(total_size / (1024 * 1024), 2),
+        "oldest_date": dates[0] if dates else None,
+        "newest_date": dates[-1] if dates else None,
+        "files_by_date": dict(files_by_date),
+    }

--- a/src/mailtag/utils/data_validation.py
+++ b/src/mailtag/utils/data_validation.py
@@ -1,0 +1,309 @@
+"""Utilities for data validation and normalization."""
+
+import json
+import re
+from email.header import decode_header
+from pathlib import Path
+
+from loguru import logger
+
+
+def normalize_email(email: str) -> str:
+    """
+    Normalize an email address.
+
+    - Strip angle brackets
+    - Decode RFC 2047 encoded headers
+    - Convert to lowercase
+    - Strip whitespace
+
+    Args:
+        email: Raw email address string
+
+    Returns:
+        Normalized email address
+    """
+    if not email:
+        return ""
+
+    email = email.strip()
+
+    # Extract email from "Name <email>" format first
+    match = re.search(r"<([^>]+)>", email)
+    if match:
+        email = match.group(1)
+    else:
+        # Strip angle brackets if present at start/end
+        email = re.sub(r"^<|>$", "", email)
+
+    # Handle RFC 2047 encoded headers (e.g., =?utf-8?b?...?=)
+    if "=?" in email and "?=" in email:
+        try:
+            decoded_parts = decode_header(email)
+            decoded_email = ""
+            for part, charset in decoded_parts:
+                if isinstance(part, bytes):
+                    decoded_email += part.decode(charset or "utf-8", errors="replace")
+                else:
+                    decoded_email += part
+            email = decoded_email
+        except Exception as e:
+            logger.debug(f"Failed to decode RFC 2047 email header: {e}")
+
+    return email.lower().strip()
+
+
+def normalize_domain(domain: str) -> str:
+    """
+    Normalize a domain name.
+
+    - Strip trailing characters (>, whitespace)
+    - Convert to lowercase
+    - Validate basic format
+
+    Args:
+        domain: Raw domain string
+
+    Returns:
+        Normalized domain
+    """
+    if not domain:
+        return ""
+
+    # Strip common artifacts
+    domain = re.sub(r"[>\s]+$", "", domain.strip())
+    domain = re.sub(r"^[<\s]+", "", domain)
+
+    return domain.lower().strip()
+
+
+def validate_domain_format(domain: str) -> bool:
+    """
+    Check if a domain has valid format.
+
+    Args:
+        domain: Domain string to validate
+
+    Returns:
+        True if valid format
+    """
+    if not domain:
+        return False
+
+    # Basic domain pattern
+    pattern = r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$"
+    return bool(re.match(pattern, domain.lower()))
+
+
+def validate_domain_classifications(db_path: Path) -> list[str]:
+    """
+    Check domain_classifications.json for issues.
+
+    Args:
+        db_path: Path to domain_classifications.json
+
+    Returns:
+        List of issue descriptions
+    """
+    issues = []
+
+    if not db_path.exists():
+        issues.append(f"File not found: {db_path}")
+        return issues
+
+    try:
+        with open(db_path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        issues.append(f"Invalid JSON: {e}")
+        return issues
+
+    for domain, category in data.items():
+        # Check for malformed domains
+        if domain != normalize_domain(domain):
+            issues.append(f"Malformed domain: '{domain}' should be '{normalize_domain(domain)}'")
+
+        # Check for invalid format
+        normalized = normalize_domain(domain)
+        if normalized and not validate_domain_format(normalized):
+            issues.append(f"Invalid domain format: '{domain}'")
+
+        # Check for empty category
+        if not category or not category.strip():
+            issues.append(f"Empty category for domain: '{domain}'")
+
+    return issues
+
+
+def validate_sender_classifications(db_path: Path) -> list[str]:
+    """
+    Check sender_classification_db.json for issues.
+
+    Args:
+        db_path: Path to sender_classification_db.json
+
+    Returns:
+        List of issue descriptions
+    """
+    issues = []
+
+    if not db_path.exists():
+        issues.append(f"File not found: {db_path}")
+        return issues
+
+    try:
+        with open(db_path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        issues.append(f"Invalid JSON: {e}")
+        return issues
+
+    for sender, categories in data.items():
+        # Check for malformed sender addresses
+        normalized = normalize_email(sender)
+        if sender != normalized:
+            issues.append(f"Sender needs normalization: '{sender}' -> '{normalized}'")
+
+        # Check for invalid category data
+        if not isinstance(categories, dict):
+            issues.append(f"Invalid categories for sender '{sender}': expected dict")
+            continue
+
+        for category, count in categories.items():
+            if not isinstance(count, int) or count < 1:
+                issues.append(f"Invalid count for '{sender}' -> '{category}': {count}")
+
+    return issues
+
+
+def fix_domain_classifications(db_path: Path) -> int:
+    """
+    Fix issues in domain_classifications.json.
+
+    Args:
+        db_path: Path to domain_classifications.json
+
+    Returns:
+        Number of entries fixed
+    """
+    if not db_path.exists():
+        return 0
+
+    with open(db_path) as f:
+        data = json.load(f)
+
+    fixed_count = 0
+    fixed_data = {}
+
+    for domain, category in data.items():
+        normalized = normalize_domain(domain)
+        if normalized != domain:
+            logger.info(f"Fixed domain: '{domain}' -> '{normalized}'")
+            fixed_count += 1
+
+        # Skip if normalized domain already exists (dedup)
+        if normalized in fixed_data:
+            logger.warning(f"Duplicate domain after normalization: '{domain}' -> '{normalized}'")
+            continue
+
+        fixed_data[normalized] = category
+
+    if fixed_count > 0:
+        with open(db_path, "w") as f:
+            json.dump(fixed_data, f, indent=2)
+        logger.info(f"Fixed {fixed_count} domain entries")
+
+    return fixed_count
+
+
+def prune_low_confidence_senders(db_path: Path, min_count: int = 3) -> int:
+    """
+    Remove sender entries with occurrence count below threshold.
+
+    Args:
+        db_path: Path to sender_classification_db.json
+        min_count: Minimum total occurrences to keep
+
+    Returns:
+        Number of entries removed
+    """
+    if not db_path.exists():
+        return 0
+
+    with open(db_path) as f:
+        data = json.load(f)
+
+    original_count = len(data)
+    pruned_data = {}
+
+    for sender, categories in data.items():
+        total_count = sum(categories.values())
+        if total_count >= min_count:
+            pruned_data[sender] = categories
+        else:
+            logger.debug(f"Pruned sender '{sender}' with count {total_count}")
+
+    pruned_count = original_count - len(pruned_data)
+
+    if pruned_count > 0:
+        with open(db_path, "w") as f:
+            json.dump(pruned_data, f, indent=2)
+        logger.info(f"Pruned {pruned_count} low-confidence sender entries (threshold: {min_count})")
+
+    return pruned_count
+
+
+def get_database_stats(db_dir: Path) -> dict:
+    """
+    Get statistics about all databases.
+
+    Args:
+        db_dir: Path to the database directory
+
+    Returns:
+        Dictionary with database statistics
+    """
+    stats = {}
+
+    # Sender classification DB
+    sender_db_path = db_dir / "sender_classification_db.json"
+    if sender_db_path.exists():
+        with open(sender_db_path) as f:
+            data = json.load(f)
+
+        total_occurrences = sum(sum(cats.values()) for cats in data.values())
+        high_confidence = sum(1 for cats in data.values() if sum(cats.values()) >= 10)
+
+        stats["sender_db"] = {
+            "entries": len(data),
+            "total_occurrences": total_occurrences,
+            "high_confidence_entries": high_confidence,
+            "size_bytes": sender_db_path.stat().st_size,
+        }
+
+    # Domain classification DB
+    domain_db_path = db_dir / "domain_classifications.json"
+    if domain_db_path.exists():
+        with open(domain_db_path) as f:
+            data = json.load(f)
+
+        unique_categories = set(data.values())
+
+        stats["domain_db"] = {
+            "entries": len(data),
+            "unique_categories": len(unique_categories),
+            "size_bytes": domain_db_path.stat().st_size,
+        }
+
+    # Validated classification DB
+    validated_db_path = db_dir / "validated_classification_db.json"
+    if validated_db_path.exists():
+        with open(validated_db_path) as f:
+            data = json.load(f)
+
+        stats["validated_db"] = {
+            "entries": len(data),
+            "size_bytes": validated_db_path.stat().st_size,
+        }
+
+    return stats

--- a/src/mailtag/utils/db_backup.py
+++ b/src/mailtag/utils/db_backup.py
@@ -1,0 +1,198 @@
+"""Utilities for database backup and restore."""
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from loguru import logger
+
+
+def backup_database(db_path: Path, backup_dir: Path | None = None) -> Path | None:
+    """
+    Create a timestamped backup of a database file.
+
+    Args:
+        db_path: Path to the database file to backup
+        backup_dir: Directory for backups (default: db/backups/)
+
+    Returns:
+        Path to the backup file, or None if source doesn't exist
+    """
+    if not db_path.exists():
+        logger.debug(f"No backup needed: {db_path} does not exist")
+        return None
+
+    if backup_dir is None:
+        backup_dir = db_path.parent / "backups"
+
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_name = f"{db_path.stem}_{timestamp}{db_path.suffix}"
+    backup_path = backup_dir / backup_name
+
+    shutil.copy2(db_path, backup_path)
+    logger.info(f"Created backup: {backup_path}")
+
+    return backup_path
+
+
+def backup_all_databases(db_dir: Path, backup_dir: Path | None = None) -> list[Path]:
+    """
+    Backup all JSON database files in the db directory.
+
+    Args:
+        db_dir: Path to the database directory
+        backup_dir: Directory for backups (default: db/backups/)
+
+    Returns:
+        List of backup file paths created
+    """
+    if backup_dir is None:
+        backup_dir = db_dir / "backups"
+
+    backups = []
+    db_files = [
+        "sender_classification_db.json",
+        "domain_classifications.json",
+        "validated_classification_db.json",
+    ]
+
+    for db_file in db_files:
+        db_path = db_dir / db_file
+        if db_path.exists():
+            backup_path = backup_database(db_path, backup_dir)
+            if backup_path:
+                backups.append(backup_path)
+
+    logger.info(f"Backed up {len(backups)} database files to {backup_dir}")
+    return backups
+
+
+def restore_database(backup_path: Path, db_path: Path) -> None:
+    """
+    Restore a database from a backup file.
+
+    Args:
+        backup_path: Path to the backup file
+        db_path: Path to restore to
+    """
+    if not backup_path.exists():
+        raise FileNotFoundError(f"Backup file not found: {backup_path}")
+
+    shutil.copy2(backup_path, db_path)
+    logger.info(f"Restored {db_path} from {backup_path}")
+
+
+def cleanup_old_backups(backup_dir: Path, keep_count: int = 10) -> int:
+    """
+    Remove old backups, keeping the most recent ones.
+
+    Args:
+        backup_dir: Directory containing backups
+        keep_count: Number of backups to keep per database type
+
+    Returns:
+        Number of backup files deleted
+    """
+    if not backup_dir.exists():
+        return 0
+
+    # Group backups by base name (e.g., sender_classification_db)
+    backups_by_type: dict[str, list[Path]] = {}
+
+    for backup_file in backup_dir.glob("*.json"):
+        # Extract base name (everything before the timestamp)
+        # Format: basename_YYYYMMDD_HHMMSS.json
+        parts = backup_file.stem.rsplit("_", 2)
+        if len(parts) >= 3:
+            base_name = parts[0]
+            if base_name not in backups_by_type:
+                backups_by_type[base_name] = []
+            backups_by_type[base_name].append(backup_file)
+
+    deleted_count = 0
+
+    for _base_name, backups in backups_by_type.items():
+        # Sort by modification time (newest first)
+        backups.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+        # Delete excess backups
+        for old_backup in backups[keep_count:]:
+            old_backup.unlink()
+            logger.debug(f"Deleted old backup: {old_backup.name}")
+            deleted_count += 1
+
+    if deleted_count > 0:
+        logger.info(f"Cleaned up {deleted_count} old backup files")
+
+    return deleted_count
+
+
+def list_backups(backup_dir: Path) -> list[dict]:
+    """
+    List all available backups with metadata.
+
+    Args:
+        backup_dir: Directory containing backups
+
+    Returns:
+        List of backup info dictionaries
+    """
+    if not backup_dir.exists():
+        return []
+
+    backups = []
+
+    for backup_file in sorted(backup_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
+        stat = backup_file.stat()
+        backups.append(
+            {
+                "path": backup_file,
+                "name": backup_file.name,
+                "size_bytes": stat.st_size,
+                "created": datetime.fromtimestamp(stat.st_mtime),
+            }
+        )
+
+    return backups
+
+
+def get_backup_stats(backup_dir: Path) -> dict:
+    """
+    Get statistics about backups.
+
+    Args:
+        backup_dir: Directory containing backups
+
+    Returns:
+        Dictionary with backup statistics
+    """
+    if not backup_dir.exists():
+        return {
+            "total_backups": 0,
+            "total_size_bytes": 0,
+            "oldest_backup": None,
+            "newest_backup": None,
+        }
+
+    backups = list(backup_dir.glob("*.json"))
+
+    if not backups:
+        return {
+            "total_backups": 0,
+            "total_size_bytes": 0,
+            "oldest_backup": None,
+            "newest_backup": None,
+        }
+
+    total_size = sum(b.stat().st_size for b in backups)
+    sorted_backups = sorted(backups, key=lambda p: p.stat().st_mtime)
+
+    return {
+        "total_backups": len(backups),
+        "total_size_bytes": total_size,
+        "total_size_mb": round(total_size / (1024 * 1024), 2),
+        "oldest_backup": sorted_backups[0].name,
+        "newest_backup": sorted_backups[-1].name,
+    }

--- a/src/mailtag/utils/domain_analyzer.py
+++ b/src/mailtag/utils/domain_analyzer.py
@@ -90,7 +90,7 @@ class DomainAnalyzer:
                     if sender not in domain_data[domain]["sender_list"]:
                         domain_data[domain]["sender_list"].append(sender)
 
-            except (json.JSONDecodeError, IOError) as e:
+            except (OSError, json.JSONDecodeError) as e:
                 logger.warning(f"Failed to process {filepath}: {e}")
                 continue
 
@@ -205,13 +205,13 @@ class DomainAnalyzer:
         try:
             with open(domain_db_path) as f:
                 domain_db = json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
+        except (OSError, json.JSONDecodeError) as e:
             logger.error(f"Failed to load domain DB: {e}")
             return {}
 
         # Analyze categories
         category_distribution = defaultdict(int)
-        for domain, category in domain_db.items():
+        for _domain, category in domain_db.items():
             category_distribution[category] += 1
 
         # Find parent categories

--- a/src/mailtag/utils/text_utils.py
+++ b/src/mailtag/utils/text_utils.py
@@ -5,7 +5,6 @@ including smart truncation, signature removal, and content extraction.
 """
 
 import re
-from typing import Tuple
 
 
 def smart_truncate(body: str, max_chars: int = 1500) -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -53,11 +53,18 @@ def generate_filters(database):
 
 def start_classification_run(provider, validate):
     """Sets up and starts the classification run."""
-    suggestion_db_path = Path("db/sender_classification_db.json")
-    validated_db_path = Path("db/validated_classification_db.json")
-    database = ClassificationDatabase(suggestion_db_path, validated_db_path)
+    from mailtag.utils.db_backup import backup_all_databases, cleanup_old_backups
 
-    # Import json here since we need it for the refresh function
+    db_dir = Path("db")
+    suggestion_db_path = db_dir / "sender_classification_db.json"
+    validated_db_path = db_dir / "validated_classification_db.json"
+
+    # Backup databases once at start of run
+    logger.info("Creating database backups...")
+    backup_all_databases(db_dir)
+    cleanup_old_backups(db_dir / "backups", keep_count=10)
+
+    database = ClassificationDatabase(suggestion_db_path, validated_db_path)
 
     providers_to_run = []
     if provider == "all":
@@ -206,6 +213,205 @@ def analyze_domains(output: str, min_emails: int, top: int):
         print()
 
     logger.info(f"Review {output_path} and add categories, then run: python scripts/update_domain_db.py")
+
+
+@cli.command()
+@click.option(
+    "--max-age",
+    default=30,
+    type=int,
+    help="Maximum age in days for pass3 files to keep.",
+)
+@click.option(
+    "--consolidate/--no-consolidate",
+    default=True,
+    help="Consolidate duplicate pass3 files from the same day.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be deleted without actually deleting.",
+)
+def cleanup(max_age: int, consolidate: bool, dry_run: bool):
+    """Clean up old data files and validate databases.
+
+    Removes pass3_manual_matching files older than --max-age days.
+    Optionally consolidates duplicate files from the same day.
+    """
+    from mailtag.utils.data_cleanup import (
+        cleanup_old_pass3_files,
+        consolidate_duplicate_pass3_files,
+        get_pass3_file_stats,
+    )
+    from mailtag.utils.data_validation import validate_domain_classifications, validate_sender_classifications
+
+    data_dir = Path("data")
+    db_dir = Path("db")
+
+    # Show current stats
+    stats = get_pass3_file_stats(data_dir)
+    print("\nPass3 Files Statistics:")
+    print("-" * 40)
+    print(f"Total files: {stats['total_files']}")
+    print(f"Total size: {stats.get('total_size_mb', 0)} MB")
+    print(f"Date range: {stats.get('oldest_date', 'N/A')} to {stats.get('newest_date', 'N/A')}")
+    print()
+
+    if dry_run:
+        print("[DRY RUN] Would perform the following operations:\n")
+
+    # Consolidate duplicates first
+    if consolidate:
+        if dry_run:
+            print("- Consolidate duplicate pass3 files (keep first and last per day)")
+        else:
+            deleted = consolidate_duplicate_pass3_files(data_dir)
+            print(f"Consolidated: deleted {deleted} duplicate files")
+
+    # Clean old files
+    if dry_run:
+        print(f"- Delete pass3 files older than {max_age} days")
+    else:
+        deleted = cleanup_old_pass3_files(data_dir, max_age)
+        print(f"Cleaned: deleted {deleted} old files")
+
+    # Validate databases
+    print("\nDatabase Validation:")
+    print("-" * 40)
+
+    domain_issues = validate_domain_classifications(db_dir / "domain_classifications.json")
+    if domain_issues:
+        print(f"Domain DB issues ({len(domain_issues)}):")
+        for issue in domain_issues[:5]:
+            print(f"  - {issue}")
+        if len(domain_issues) > 5:
+            print(f"  ... and {len(domain_issues) - 5} more")
+    else:
+        print("Domain DB: OK")
+
+    sender_issues = validate_sender_classifications(db_dir / "sender_classification_db.json")
+    if sender_issues:
+        print(f"Sender DB issues ({len(sender_issues)}):")
+        for issue in sender_issues[:5]:
+            print(f"  - {issue}")
+        if len(sender_issues) > 5:
+            print(f"  ... and {len(sender_issues) - 5} more")
+    else:
+        print("Sender DB: OK")
+
+
+@cli.command("db-stats")
+def db_stats():
+    """Show database statistics and health check."""
+    from mailtag.utils.data_cleanup import get_pass3_file_stats
+    from mailtag.utils.data_validation import get_database_stats
+    from mailtag.utils.db_backup import get_backup_stats
+
+    db_dir = Path("db")
+    data_dir = Path("data")
+    backup_dir = db_dir / "backups"
+
+    # Database stats
+    stats = get_database_stats(db_dir)
+
+    print("\nDatabase Statistics:")
+    print("=" * 60)
+
+    if "sender_db" in stats:
+        s = stats["sender_db"]
+        print("\nSender Classification DB:")
+        print(f"  Entries: {s['entries']}")
+        print(f"  Total occurrences: {s['total_occurrences']}")
+        print(f"  High-confidence entries (10+): {s['high_confidence_entries']}")
+        print(f"  Size: {s['size_bytes']:,} bytes")
+
+    if "domain_db" in stats:
+        d = stats["domain_db"]
+        print("\nDomain Classification DB:")
+        print(f"  Entries: {d['entries']}")
+        print(f"  Unique categories: {d['unique_categories']}")
+        print(f"  Size: {d['size_bytes']:,} bytes")
+
+    if "validated_db" in stats:
+        v = stats["validated_db"]
+        print("\nValidated Classification DB:")
+        print(f"  Entries: {v['entries']}")
+        print(f"  Size: {v['size_bytes']:,} bytes")
+
+    # Pass3 stats
+    pass3_stats = get_pass3_file_stats(data_dir)
+    print("\nPass3 Manual Matching Files:")
+    print(f"  Total files: {pass3_stats['total_files']}")
+    print(f"  Total size: {pass3_stats.get('total_size_mb', 0)} MB")
+    if pass3_stats.get('oldest_date'):
+        print(f"  Date range: {pass3_stats['oldest_date']} to {pass3_stats['newest_date']}")
+
+    # Backup stats
+    backup_stats = get_backup_stats(backup_dir)
+    print("\nBackups:")
+    print(f"  Total backups: {backup_stats['total_backups']}")
+    if backup_stats['total_backups'] > 0:
+        print(f"  Total size: {backup_stats.get('total_size_mb', 0)} MB")
+        print(f"  Oldest: {backup_stats.get('oldest_backup', 'N/A')}")
+        print(f"  Newest: {backup_stats.get('newest_backup', 'N/A')}")
+
+
+@cli.command("prune-db")
+@click.option(
+    "--min-count",
+    default=3,
+    type=int,
+    help="Minimum occurrence count to keep (entries below this are removed).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be pruned without actually removing.",
+)
+def prune_db(min_count: int, dry_run: bool):
+    """Remove low-confidence entries from sender classification database.
+
+    Entries with total occurrence count below --min-count are removed.
+    This helps reduce database size and improve signal quality.
+    """
+    import json
+
+    from mailtag.utils.data_validation import prune_low_confidence_senders
+
+    db_path = Path("db/sender_classification_db.json")
+
+    if not db_path.exists():
+        print("Sender classification database not found.")
+        return
+
+    # Load current data for analysis
+    with open(db_path) as f:
+        data = json.load(f)
+
+    total_entries = len(data)
+    would_prune = sum(1 for cats in data.values() if sum(cats.values()) < min_count)
+
+    print("\nSender Classification Database Pruning:")
+    print("=" * 60)
+    print(f"Current entries: {total_entries}")
+    print(f"Entries below threshold ({min_count}): {would_prune}")
+    print(f"Would keep: {total_entries - would_prune}")
+    print(f"Reduction: {would_prune / total_entries * 100:.1f}%")
+
+    if dry_run:
+        print("\n[DRY RUN] No changes made.")
+        return
+
+    if would_prune == 0:
+        print("\nNo entries to prune.")
+        return
+
+    # Confirm before pruning
+    if click.confirm(f"\nRemove {would_prune} low-confidence entries?"):
+        pruned = prune_low_confidence_senders(db_path, min_count)
+        print(f"\nPruned {pruned} entries from database.")
+    else:
+        print("\nPruning cancelled.")
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -343,14 +343,14 @@ def db_stats():
     print("\nPass3 Manual Matching Files:")
     print(f"  Total files: {pass3_stats['total_files']}")
     print(f"  Total size: {pass3_stats.get('total_size_mb', 0)} MB")
-    if pass3_stats.get('oldest_date'):
+    if pass3_stats.get("oldest_date"):
         print(f"  Date range: {pass3_stats['oldest_date']} to {pass3_stats['newest_date']}")
 
     # Backup stats
     backup_stats = get_backup_stats(backup_dir)
     print("\nBackups:")
     print(f"  Total backups: {backup_stats['total_backups']}")
-    if backup_stats['total_backups'] > 0:
+    if backup_stats["total_backups"] > 0:
         print(f"  Total size: {backup_stats.get('total_size_mb', 0)} MB")
         print(f"  Oldest: {backup_stats.get('oldest_backup', 'N/A')}")
         print(f"  Newest: {backup_stats.get('newest_backup', 'N/A')}")

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -2,11 +2,11 @@ from pathlib import Path
 
 import pandas as pd
 import streamlit as st
+from mailtag.mail_service import MailService
 
 from mailtag.classifier import Classifier
 from mailtag.config import CONFIG
 from mailtag.database import ClassificationDatabase
-from mailtag.mail_service import MailService
 
 st.set_page_config(page_title="MailTag Classifier", layout="wide")
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,63 @@
+# tests/
+
+Test suite using pytest with mocking support.
+
+## Test Organization
+
+### Core Module Tests
+- **test_classifier.py** - Classification engine tests
+- **test_database.py** - JSON database operations
+- **test_config.py** - Configuration loading and validation
+- **test_main.py** - CLI entry point tests
+
+### Provider Tests
+- **test_imap_service.py** - IMAP operations with mock client
+- **test_gmail_service.py** - Gmail API operations
+- **test_gmail_auth.py** - OAuth flow testing
+- **test_missing_google_deps.py** - Graceful handling when Gmail deps missing
+
+### Utility Tests
+- **test_text_utils.py** - Text processing functions
+- **test_domain_analyzer.py** - Domain analysis utilities
+- **test_filter_generator.py** - Email filter generation
+
+### Feature Tests
+- **test_ai_confidence.py** - AI confidence scoring
+- **test_classification_metrics.py** - Metrics collection
+- **test_logging_config.py** - Logging setup
+
+## Test Helpers
+- **conftest.py** - Shared pytest fixtures
+- **mock_imap_client.py** - IMAP client mock implementation
+- **mock_gmail_service.py** - Gmail service mock
+
+## Running Tests
+
+```bash
+# All tests with coverage
+uv run pytest --cov --cov-branch --cov-report=xml
+
+# Fast run without coverage
+uv run pytest
+
+# Specific file
+uv run pytest tests/test_classifier.py
+
+# Specific test
+uv run pytest tests/test_classifier.py::test_function_name
+
+# Verbose output
+uv run pytest -v
+```
+
+## Key Libraries
+- `pytest` - Test framework
+- `pytest-mock` - Mocking support
+- `pytest-cov` - Coverage reporting
+- `faker` - Mock data generation
+
+## Conventions
+- Use fixtures from `conftest.py` for common setup
+- Mock external services (IMAP, Gmail API, AI calls)
+- Test edge cases and error conditions
+- CI runs on Python 3.10 minimum

--- a/tests/test_ai_confidence.py
+++ b/tests/test_ai_confidence.py
@@ -13,6 +13,7 @@ from mailtag.config import (
     GmailConfig,
     ImapConfig,
     LoggingConfig,
+    MLXConfig,
 )
 from mailtag.database import ClassificationDatabase
 from mailtag.models import Email
@@ -39,6 +40,7 @@ def mock_config():
             unclassified_folder_name="Unclassified",
             junk_folder_name="Junk",
         ),
+        mlx=MLXConfig(enabled=False),  # Disable MLX for unit tests
     )
 
 
@@ -199,72 +201,51 @@ class TestLegacyResponseParsing:
 class TestConfidenceThreshold:
     """Test confidence threshold enforcement."""
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_high_confidence_accepted(self, mock_completion, classifier, sample_email):
+    def test_high_confidence_accepted(self, classifier, sample_email):
         """Test that high confidence classifications are accepted."""
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "Finance/Banking", "confidence": 0.95, "reason": "Invoice"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/Banking", 0.95, "Invoice")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "Finance/Banking"
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_low_confidence_rejected(self, mock_completion, classifier, sample_email):
+    def test_low_confidence_rejected(self, classifier, sample_email):
         """Test that low confidence classifications are rejected."""
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "Finance/Banking", "confidence": 0.50, "reason": "Not sure"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/Banking", 0.50, "Not sure")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "À Classer"
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_threshold_boundary(self, mock_completion, classifier, sample_email):
+    def test_threshold_boundary(self, classifier, sample_email):
         """Test classification at threshold boundary (0.85)."""
-        # Exactly at threshold should be accepted
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "Finance/Banking", "confidence": 0.85, "reason": "Test"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components - exactly at threshold should be accepted
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/Banking", 0.85, "Test")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "Finance/Banking"
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_just_below_threshold(self, mock_completion, classifier, sample_email):
+    def test_just_below_threshold(self, classifier, sample_email):
         """Test classification just below threshold."""
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "Finance/Banking", "confidence": 0.84, "reason": "Test"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/Banking", 0.84, "Test")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "À Classer"
 
@@ -272,61 +253,46 @@ class TestConfidenceThreshold:
 class TestInvalidCategoryHandling:
     """Test handling of invalid category suggestions."""
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_invalid_category_high_confidence(self, mock_completion, classifier, sample_email):
+    def test_invalid_category_high_confidence(self, classifier, sample_email):
         """Test that invalid categories are rejected even with high confidence."""
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "InvalidCategory", "confidence": 0.99, "reason": "Test"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components with invalid category
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("InvalidCategory", 0.99, "Test")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "À Classer"
 
-    @patch("mailtag.classifier.litellm.completion")
     def test_new_folder_proposal_valid_parent(
-        self, mock_completion, classifier, sample_email, mock_folder_analyzer
+        self, classifier, sample_email, mock_folder_analyzer
     ):
         """Test new folder proposal with valid parent."""
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "Finance/NewFolder", "confidence": 0.90, "reason": "New category"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components with new folder proposal
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/NewFolder", 0.90, "New category")
+        classifier._mlx_llm = mock_llm
         mock_folder_analyzer.is_valid_parent_folder.return_value = True
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         # Should be logged as proposal and return "À Classer"
         assert result == "À Classer"
 
-    @patch("mailtag.classifier.litellm.completion")
     def test_new_folder_proposal_invalid_parent(
-        self, mock_completion, classifier, sample_email, mock_folder_analyzer
+        self, classifier, sample_email, mock_folder_analyzer
     ):
         """Test new folder proposal with invalid parent."""
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "InvalidParent/NewFolder", "confidence": 0.90, "reason": "Test"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components with invalid parent proposal
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("InvalidParent/NewFolder", 0.90, "Test")
+        classifier._mlx_llm = mock_llm
         mock_folder_analyzer.is_valid_parent_folder.return_value = False
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "À Classer"
 
@@ -334,41 +300,30 @@ class TestInvalidCategoryHandling:
 class TestCaching:
     """Test AI response caching."""
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_cache_hit(self, mock_completion, classifier, sample_email):
+    def test_cache_hit(self, classifier, sample_email):
         """Test that cached responses are used."""
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "Finance/Banking", "confidence": 0.95, "reason": "Test"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/Banking", 0.95, "Test")
+        classifier._mlx_llm = mock_llm
 
-        # First call - should hit API
-        result1 = classifier._get_category_from_ai(sample_email)
-        assert result1 == "Finance/Banking"
-        assert mock_completion.call_count == 1
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            # First call - should call LLM
+            result1 = classifier._get_category_from_ai(sample_email)
+            assert result1 == "Finance/Banking"
+            assert mock_llm.classify.call_count == 1
 
-        # Second call with same email - should use cache
-        result2 = classifier._get_category_from_ai(sample_email)
-        assert result2 == "Finance/Banking"
-        assert mock_completion.call_count == 1  # No additional API call
+            # Second call with same email - should use cache
+            result2 = classifier._get_category_from_ai(sample_email)
+            assert result2 == "Finance/Banking"
+            assert mock_llm.classify.call_count == 1  # No additional call
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_cache_key_includes_subject(self, mock_completion, classifier):
+    def test_cache_key_includes_subject(self, classifier):
         """Test that cache key includes subject (different subjects = different cache entries)."""
-        mock_completion.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"category": "Finance/Banking", "confidence": 0.95, "reason": "Test"}'
-                    )
-                )
-            ]
-        )
+        # Mock MLX components
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/Banking", 0.95, "Test")
+        classifier._mlx_llm = mock_llm
 
         email1 = Email(
             msg_id="1",
@@ -386,42 +341,50 @@ class TestCaching:
             body="Body",
         )
 
-        classifier._get_category_from_ai(email1)
-        classifier._get_category_from_ai(email2)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            classifier._get_category_from_ai(email1)
+            classifier._get_category_from_ai(email2)
 
-        # Should be 2 API calls (different cache keys)
-        assert mock_completion.call_count == 2
+        # Should be 2 LLM calls (different cache keys)
+        assert mock_llm.classify.call_count == 2
 
 
-class TestBackwardCompatibility:
-    """Test backward compatibility with legacy string responses."""
+class TestMLXEdgeCases:
+    """Test edge cases with MLX LLM responses."""
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_legacy_string_response_valid_category(self, mock_completion, classifier, sample_email):
-        """Test that legacy string responses still work."""
-        mock_completion.return_value = Mock(choices=[Mock(message=Mock(content="Finance/Banking"))])
+    def test_valid_category_response(self, classifier, sample_email):
+        """Test that valid category responses work correctly."""
+        # Mock MLX components with valid category
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/Banking", 0.95, "Test reason")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "Finance/Banking"
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_legacy_string_response_invalid_category(self, mock_completion, classifier, sample_email):
-        """Test that invalid legacy responses are handled."""
-        mock_completion.return_value = Mock(choices=[Mock(message=Mock(content="InvalidCategory"))])
+    def test_empty_category_response(self, classifier, sample_email):
+        """Test that empty category responses are handled."""
+        # Mock MLX components with empty category
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("", 0.95, "No match found")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "À Classer"
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_legacy_uncertain_response(self, mock_completion, classifier, sample_email):
-        """Test legacy UNCERTAIN format."""
-        mock_completion.return_value = Mock(
-            choices=[Mock(message=Mock(content="UNCERTAIN: Finance/Banking"))]
-        )
+    def test_low_confidence_with_valid_category(self, classifier, sample_email):
+        """Test that low confidence classifications route to À Classer."""
+        # Mock MLX components with low confidence
+        mock_llm = Mock()
+        mock_llm.classify.return_value = ("Finance/Banking", 0.40, "Not confident")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "À Classer"
 
@@ -429,24 +392,32 @@ class TestBackwardCompatibility:
 class TestErrorHandling:
     """Test error handling in AI classification."""
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_api_exception(self, mock_completion, classifier, sample_email):
-        """Test handling of API exceptions."""
-        mock_completion.side_effect = Exception("API Error")
+    def test_llm_exception(self, classifier, sample_email):
+        """Test handling of LLM exceptions."""
+        # Mock MLX components that raise an exception
+        mock_llm = Mock()
+        mock_llm.classify.side_effect = Exception("LLM Error")
+        classifier._mlx_llm = mock_llm
 
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
         assert result == "(Model Error)"
 
-    @patch("mailtag.classifier.litellm.completion")
-    def test_malformed_json_fallback(self, mock_completion, classifier, sample_email):
-        """Test that malformed JSON falls back to legacy parsing."""
-        mock_completion.return_value = Mock(
-            choices=[Mock(message=Mock(content='{"category": "Finance/Banking"'))]  # Missing closing brace
-        )
+    def test_mlx_not_initialized(self, classifier, sample_email):
+        """Test handling when MLX components are not initialized."""
+        # Set _mlx_llm to None - _init_mlx_components returns True but _mlx_llm is None
+        classifier._mlx_llm = None
 
-        # Should fall back to legacy parsing and treat as plain text
-        result = classifier._get_category_from_ai(sample_email)
+        with patch.object(classifier, "_init_mlx_components", return_value=True):
+            result = classifier._get_category_from_ai(sample_email)
 
-        # Legacy parser will see the malformed JSON as invalid category
-        assert result == "À Classer"
+        assert result == "(Model Error)"
+
+    def test_mlx_disabled_returns_error(self, classifier, sample_email):
+        """Test that disabled MLX returns model error."""
+        # When MLX is disabled and can't initialize, it should return error
+        with patch.object(classifier, "_init_mlx_components", return_value=False):
+            result = classifier._get_category_from_ai(sample_email)
+
+        assert result == "(Model Error)"

--- a/tests/test_ai_confidence.py
+++ b/tests/test_ai_confidence.py
@@ -104,7 +104,10 @@ class TestAIJsonResponseParsing:
 
     def test_parse_json_with_markdown_code_block(self, classifier):
         """Test parsing JSON wrapped in markdown code blocks."""
-        json_response = '```json\n{"category": "Shopping/Online", "confidence": 0.88, "reason": "Order confirmation"}\n```'
+        json_response = (
+            '```json\n{"category": "Shopping/Online", '
+            '"confidence": 0.88, "reason": "Order confirmation"}\n```'
+        )
         category, confidence, reason = classifier._parse_ai_json_response(json_response)
 
         assert category == "Shopping/Online"
@@ -113,7 +116,10 @@ class TestAIJsonResponseParsing:
 
     def test_parse_json_with_extra_text(self, classifier):
         """Test parsing JSON with extra text around it."""
-        json_response = 'Here is my classification: {"category": "Services/Professional", "confidence": 0.92, "reason": "LinkedIn"} hope this helps'
+        json_response = (
+            'Here is my classification: {"category": "Services/Professional", '
+            '"confidence": 0.92, "reason": "LinkedIn"} hope this helps'
+        )
         category, confidence, reason = classifier._parse_ai_json_response(json_response)
 
         assert category == "Services/Professional"
@@ -265,9 +271,7 @@ class TestInvalidCategoryHandling:
 
         assert result == "À Classer"
 
-    def test_new_folder_proposal_valid_parent(
-        self, classifier, sample_email, mock_folder_analyzer
-    ):
+    def test_new_folder_proposal_valid_parent(self, classifier, sample_email, mock_folder_analyzer):
         """Test new folder proposal with valid parent."""
         # Mock MLX components with new folder proposal
         mock_llm = Mock()
@@ -281,9 +285,7 @@ class TestInvalidCategoryHandling:
         # Should be logged as proposal and return "À Classer"
         assert result == "À Classer"
 
-    def test_new_folder_proposal_invalid_parent(
-        self, classifier, sample_email, mock_folder_analyzer
-    ):
+    def test_new_folder_proposal_invalid_parent(self, classifier, sample_email, mock_folder_analyzer):
         """Test new folder proposal with invalid parent."""
         # Mock MLX components with invalid parent proposal
         mock_llm = Mock()

--- a/tests/test_classification_metrics.py
+++ b/tests/test_classification_metrics.py
@@ -16,6 +16,7 @@ from mailtag.config import (
     GmailConfig,
     ImapConfig,
     LoggingConfig,
+    MLXConfig,
 )
 from mailtag.database import ClassificationDatabase
 from mailtag.metrics import METRICS, ClassificationMetrics
@@ -51,6 +52,7 @@ def mock_config():
             unclassified_folder_name="Unclassified",
             junk_folder_name="Junk",
         ),
+        mlx=MLXConfig(enabled=False),  # Disable MLX for unit tests
     )
 
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from pathlib import Path
 
 import pytest
-import yaml
 from pytest_mock import MockerFixture
 
 from mailtag.classifier import Classifier
@@ -14,6 +13,7 @@ from mailtag.config import (
     GmailConfig,
     ImapConfig,
     LoggingConfig,
+    MLXConfig,
 )
 from mailtag.database import ClassificationDatabase
 from mailtag.models import Email
@@ -29,6 +29,8 @@ def mock_db(mocker: MockerFixture) -> MockerFixture:
     db.get_dominant_classification.side_effect = (
         lambda sender: list(db.validated_db.get(sender, {}).keys())[0] if sender in db.validated_db else None
     )
+    # Default: no domain classification
+    db.get_category_by_domain.return_value = None
     return db
 
 
@@ -39,6 +41,7 @@ def config() -> AppConfig:
         general=GeneralConfig(
             ollama_model="test-model",
             api_base="http://localhost:11434",
+            use_imap_folders_for_classification=False,  # Use schema-based categories
         ),
         logging=LoggingConfig(level="DEBUG", file=""),
         classifier=ClassifierConfig(
@@ -54,34 +57,23 @@ def config() -> AppConfig:
             unclassified_folder_name="Unclassified",
             junk_folder_name="Junk",
         ),
+        mlx=MLXConfig(enabled=False),  # Disable MLX for unit tests
     )
 
 
 @pytest.fixture
 def classifier(config: AppConfig, mock_db: MockerFixture, mocker: MockerFixture) -> Classifier:
     """Returns a Classifier instance with a mocked database."""
-    schema_content = """
-    - name: Finances
-      sublabels:
-        - name: Bloomberg
-    - name: Services
-      sublabels:
-        - name: Skylum
-    - name: À Classer
-    """
-    # Mock Path object to control file operations
-    mock_path_constructor = mocker.patch("pathlib.Path")
-    mock_path_instance = mock_path_constructor.return_value
-    mock_path_instance.exists.return_value = True
-    # Create a mock file object for the context manager
-    mock_file = mocker.mock_open(read_data=schema_content)
-    mock_path_instance.open.return_value = mock_file.return_value
-
-    # Mock yaml.safe_load to return the parsed schema
-    mocker.patch("yaml.safe_load", return_value=yaml.safe_load(schema_content))
-
     # Initialize the classifier
     classifier_instance = Classifier(config=config, database=mock_db)
+
+    # Directly set the categories for testing
+    classifier_instance.categories = [
+        "Finances/Bloomberg",
+        "Services/Skylum",
+        "À Classer",
+    ]
+
     # Mock the proposal file to prevent actual file writes
     classifier_instance.proposal_file = mocker.MagicMock(spec=Path)
     return classifier_instance

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,8 +44,12 @@ token_file = "token.json"
     return config_path
 
 
-def test_load_config_success(mock_config_file: Path):
+def test_load_config_success(mock_config_file: Path, monkeypatch):
     """Tests that the config is loaded correctly from a valid file."""
+    # Clear environment variables that override config file
+    for env_var in ["MODEL", "MODEL_NAME", "OLLAMA_API_URL", "API_BASE", "IMAP_USER", "IMAP_PASSWORD"]:
+        monkeypatch.delenv(env_var, raising=False)
+
     config = load_config(mock_config_file)
     assert isinstance(config, AppConfig)
     assert config.general.ollama_model == "test-model"

--- a/tests/test_data_cleanup.py
+++ b/tests/test_data_cleanup.py
@@ -1,0 +1,131 @@
+"""Tests for data cleanup utilities."""
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from mailtag.utils.data_cleanup import (
+    cleanup_old_pass3_files,
+    consolidate_duplicate_pass3_files,
+    get_pass3_file_stats,
+)
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    """Create a temporary data directory with pass3 files."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    return data_dir
+
+
+def create_pass3_file(data_dir: Path, date_str: str, time_str: str) -> Path:
+    """Helper to create a pass3 file with given date and time."""
+    filename = f"pass3_manual_matching_{date_str}_{time_str}.json"
+    file_path = data_dir / filename
+    file_path.write_text(
+        json.dumps({"timestamp": f"{date_str}T{time_str}", "emails_for_manual_matching": []})
+    )
+    return file_path
+
+
+class TestCleanupOldPass3Files:
+    def test_cleanup_old_files(self, data_dir: Path):
+        """Test that old files are deleted."""
+        today = datetime.now()
+        old_date = (today - timedelta(days=35)).strftime("%Y%m%d")
+        recent_date = (today - timedelta(days=5)).strftime("%Y%m%d")
+
+        create_pass3_file(data_dir, old_date, "120000")
+        create_pass3_file(data_dir, recent_date, "120000")
+
+        deleted = cleanup_old_pass3_files(data_dir, max_age_days=30)
+
+        assert deleted == 1
+        files = list(data_dir.glob("pass3_manual_matching_*.json"))
+        assert len(files) == 1
+        assert recent_date in files[0].name
+
+    def test_keep_recent_files(self, data_dir: Path):
+        """Test that recent files are kept."""
+        today = datetime.now()
+        recent_date = (today - timedelta(days=5)).strftime("%Y%m%d")
+
+        create_pass3_file(data_dir, recent_date, "120000")
+        create_pass3_file(data_dir, recent_date, "130000")
+
+        deleted = cleanup_old_pass3_files(data_dir, max_age_days=30)
+
+        assert deleted == 0
+        files = list(data_dir.glob("pass3_manual_matching_*.json"))
+        assert len(files) == 2
+
+    def test_empty_directory(self, data_dir: Path):
+        """Test cleanup on empty directory."""
+        deleted = cleanup_old_pass3_files(data_dir, max_age_days=30)
+        assert deleted == 0
+
+
+class TestConsolidateDuplicatePass3Files:
+    def test_consolidate_same_day_files(self, data_dir: Path):
+        """Test that duplicate files from same day are consolidated."""
+        date_str = "20251225"
+        create_pass3_file(data_dir, date_str, "100000")  # First - keep
+        create_pass3_file(data_dir, date_str, "110000")  # Middle - delete
+        create_pass3_file(data_dir, date_str, "120000")  # Middle - delete
+        create_pass3_file(data_dir, date_str, "130000")  # Last - keep
+
+        deleted = consolidate_duplicate_pass3_files(data_dir)
+
+        assert deleted == 2
+        files = sorted(data_dir.glob("pass3_manual_matching_*.json"))
+        assert len(files) == 2
+        assert "100000" in files[0].name
+        assert "130000" in files[1].name
+
+    def test_keep_single_file(self, data_dir: Path):
+        """Test that single file per day is kept."""
+        create_pass3_file(data_dir, "20251225", "120000")
+
+        deleted = consolidate_duplicate_pass3_files(data_dir)
+
+        assert deleted == 0
+        files = list(data_dir.glob("pass3_manual_matching_*.json"))
+        assert len(files) == 1
+
+    def test_keep_two_files(self, data_dir: Path):
+        """Test that two files per day are both kept."""
+        create_pass3_file(data_dir, "20251225", "100000")
+        create_pass3_file(data_dir, "20251225", "120000")
+
+        deleted = consolidate_duplicate_pass3_files(data_dir)
+
+        assert deleted == 0
+        files = list(data_dir.glob("pass3_manual_matching_*.json"))
+        assert len(files) == 2
+
+
+class TestGetPass3FileStats:
+    def test_stats_with_files(self, data_dir: Path):
+        """Test stats calculation with multiple files."""
+        create_pass3_file(data_dir, "20251220", "100000")
+        create_pass3_file(data_dir, "20251225", "120000")
+        create_pass3_file(data_dir, "20251225", "130000")
+
+        stats = get_pass3_file_stats(data_dir)
+
+        assert stats["total_files"] == 3
+        assert stats["oldest_date"] == "20251220"
+        assert stats["newest_date"] == "20251225"
+        assert stats["files_by_date"]["20251220"] == 1
+        assert stats["files_by_date"]["20251225"] == 2
+
+    def test_stats_empty_directory(self, data_dir: Path):
+        """Test stats on empty directory."""
+        stats = get_pass3_file_stats(data_dir)
+
+        assert stats["total_files"] == 0
+        assert stats["oldest_date"] is None
+        assert stats["newest_date"] is None

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,0 +1,215 @@
+"""Tests for data validation utilities."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mailtag.utils.data_validation import (
+    fix_domain_classifications,
+    get_database_stats,
+    normalize_domain,
+    normalize_email,
+    prune_low_confidence_senders,
+    validate_domain_classifications,
+    validate_domain_format,
+    validate_sender_classifications,
+)
+
+
+class TestNormalizeEmail:
+    def test_simple_email(self):
+        """Test normalizing a simple email."""
+        assert normalize_email("Test@Example.COM") == "test@example.com"
+
+    def test_email_with_angle_brackets(self):
+        """Test normalizing email with angle brackets."""
+        assert normalize_email("<test@example.com>") == "test@example.com"
+
+    def test_email_with_name(self):
+        """Test normalizing email with display name."""
+        # The normalize_email function extracts the email from angle brackets
+        result = normalize_email("John Doe <john@example.com>")
+        assert result == "john@example.com"
+
+    def test_empty_email(self):
+        """Test normalizing empty email."""
+        assert normalize_email("") == ""
+
+    def test_email_with_whitespace(self):
+        """Test normalizing email with whitespace."""
+        assert normalize_email("  test@example.com  ") == "test@example.com"
+
+
+class TestNormalizeDomain:
+    def test_simple_domain(self):
+        """Test normalizing a simple domain."""
+        assert normalize_domain("Example.COM") == "example.com"
+
+    def test_domain_with_trailing_gt(self):
+        """Test normalizing domain with trailing >."""
+        assert normalize_domain("example.com>") == "example.com"
+
+    def test_domain_with_angle_brackets(self):
+        """Test normalizing domain with angle brackets."""
+        assert normalize_domain("<example.com>") == "example.com"
+
+    def test_empty_domain(self):
+        """Test normalizing empty domain."""
+        assert normalize_domain("") == ""
+
+
+class TestValidateDomainFormat:
+    def test_valid_domain(self):
+        """Test valid domain formats."""
+        assert validate_domain_format("example.com") is True
+        assert validate_domain_format("sub.example.com") is True
+        assert validate_domain_format("example.co.uk") is True
+
+    def test_invalid_domain(self):
+        """Test invalid domain formats."""
+        assert validate_domain_format("") is False
+        assert validate_domain_format("example") is False
+        assert validate_domain_format("-example.com") is False
+
+
+class TestValidateDomainClassifications:
+    def test_valid_db(self, tmp_path: Path):
+        """Test validation of valid database."""
+        db_path = tmp_path / "domain_db.json"
+        db_path.write_text(json.dumps({"example.com": "Category/Sub"}))
+
+        issues = validate_domain_classifications(db_path)
+        assert issues == []
+
+    def test_malformed_domain(self, tmp_path: Path):
+        """Test detection of malformed domain."""
+        db_path = tmp_path / "domain_db.json"
+        db_path.write_text(json.dumps({"example.com>": "Category"}))
+
+        issues = validate_domain_classifications(db_path)
+        assert len(issues) == 1
+        assert "Malformed domain" in issues[0]
+
+    def test_empty_category(self, tmp_path: Path):
+        """Test detection of empty category."""
+        db_path = tmp_path / "domain_db.json"
+        db_path.write_text(json.dumps({"example.com": ""}))
+
+        issues = validate_domain_classifications(db_path)
+        assert len(issues) == 1
+        assert "Empty category" in issues[0]
+
+    def test_missing_file(self, tmp_path: Path):
+        """Test validation of missing file."""
+        db_path = tmp_path / "nonexistent.json"
+        issues = validate_domain_classifications(db_path)
+        assert len(issues) == 1
+        assert "File not found" in issues[0]
+
+
+class TestValidateSenderClassifications:
+    def test_valid_db(self, tmp_path: Path):
+        """Test validation of valid database."""
+        db_path = tmp_path / "sender_db.json"
+        db_path.write_text(json.dumps({"test@example.com": {"Category": 5}}))
+
+        issues = validate_sender_classifications(db_path)
+        assert issues == []
+
+    def test_needs_normalization(self, tmp_path: Path):
+        """Test detection of sender needing normalization."""
+        db_path = tmp_path / "sender_db.json"
+        db_path.write_text(json.dumps({"<Test@Example.COM>": {"Category": 1}}))
+
+        issues = validate_sender_classifications(db_path)
+        assert len(issues) == 1
+        assert "needs normalization" in issues[0]
+
+
+class TestFixDomainClassifications:
+    def test_fix_malformed_domains(self, tmp_path: Path):
+        """Test fixing malformed domains."""
+        db_path = tmp_path / "domain_db.json"
+        db_path.write_text(json.dumps({"example.com>": "Category1", "good.com": "Category2"}))
+
+        fixed = fix_domain_classifications(db_path)
+
+        assert fixed == 1
+        with open(db_path) as f:
+            data = json.load(f)
+        assert "example.com" in data
+        assert "example.com>" not in data
+
+
+class TestPruneLowConfidenceSenders:
+    def test_prune_low_count(self, tmp_path: Path):
+        """Test pruning low-count entries."""
+        db_path = tmp_path / "sender_db.json"
+        db_path.write_text(
+            json.dumps(
+                {
+                    "low@example.com": {"Category": 1},
+                    "high@example.com": {"Category": 10},
+                }
+            )
+        )
+
+        pruned = prune_low_confidence_senders(db_path, min_count=3)
+
+        assert pruned == 1
+        with open(db_path) as f:
+            data = json.load(f)
+        assert "low@example.com" not in data
+        assert "high@example.com" in data
+
+    def test_no_prune_needed(self, tmp_path: Path):
+        """Test when no pruning is needed."""
+        db_path = tmp_path / "sender_db.json"
+        db_path.write_text(json.dumps({"high@example.com": {"Category": 10}}))
+
+        pruned = prune_low_confidence_senders(db_path, min_count=3)
+        assert pruned == 0
+
+
+class TestGetDatabaseStats:
+    def test_stats_with_all_dbs(self, tmp_path: Path):
+        """Test stats with all databases present."""
+        # Create sender db
+        sender_db = tmp_path / "sender_classification_db.json"
+        sender_db.write_text(
+            json.dumps(
+                {
+                    "a@test.com": {"Cat1": 5},
+                    "b@test.com": {"Cat2": 15},
+                }
+            )
+        )
+
+        # Create domain db
+        domain_db = tmp_path / "domain_classifications.json"
+        domain_db.write_text(
+            json.dumps(
+                {
+                    "test.com": "Category1",
+                    "example.com": "Category2",
+                }
+            )
+        )
+
+        # Create validated db
+        validated_db = tmp_path / "validated_classification_db.json"
+        validated_db.write_text(json.dumps({}))
+
+        stats = get_database_stats(tmp_path)
+
+        assert "sender_db" in stats
+        assert stats["sender_db"]["entries"] == 2
+        assert stats["sender_db"]["high_confidence_entries"] == 1
+
+        assert "domain_db" in stats
+        assert stats["domain_db"]["entries"] == 2
+        assert stats["domain_db"]["unique_categories"] == 2
+
+        assert "validated_db" in stats
+        assert stats["validated_db"]["entries"] == 0

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from mailtag.utils.data_validation import (
     fix_domain_classifications,
     get_database_stats,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,128 +1,165 @@
 import json
 from collections import defaultdict
-from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
 
 from mailtag.database import ClassificationDatabase
 
 
 @pytest.fixture
-def mock_suggestion_db_path(mocker: MockerFixture) -> MockerFixture:
-    """Fixture for a mocked suggestion database path."""
-    return mocker.MagicMock(spec=Path)
+def db_paths(tmp_path):
+    """Fixture providing temp paths for database files."""
+    return {
+        "suggestion": tmp_path / "suggestion_db.json",
+        "validated": tmp_path / "validated_db.json",
+        "domain": tmp_path / "domain_db.json",
+    }
 
 
-@pytest.fixture
-def mock_validated_db_path(mocker: MockerFixture) -> MockerFixture:
-    """Fixture for a mocked validated database path."""
-    return mocker.MagicMock(spec=Path)
-
-
-def test_load_db_file_not_found(
-    mock_suggestion_db_path: MockerFixture, mock_validated_db_path: MockerFixture
-):
+def test_load_db_file_not_found(db_paths):
     """Tests that an empty db is created when the file doesn't exist."""
-    mock_suggestion_db_path.exists.return_value = False
-    mock_validated_db_path.exists.return_value = False
     db = ClassificationDatabase(
-        suggestion_db_path=mock_suggestion_db_path, validated_db_path=mock_validated_db_path
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
     )
     assert db.suggestion_db == defaultdict(lambda: defaultdict(int))
     assert db.validated_db == defaultdict(lambda: defaultdict(int))
 
 
-def test_load_db_with_content(
-    mock_suggestion_db_path: MockerFixture, mock_validated_db_path: MockerFixture, mocker: MockerFixture
-):
+def test_load_db_with_content(db_paths):
     """Tests loading a database with existing content."""
     suggestion_db_content = {
         "sender@example.com": {"Finance/Bloomberg": 1},
         "another@sender.com": {"À Classer": 5},
     }
     validated_db_content = {"validated@sender.com": {"Validated/Category": 1}}
-    mock_suggestion_db_path.exists.return_value = True
-    mock_validated_db_path.exists.return_value = True
-    mocker.patch.object(
-        mock_suggestion_db_path, "open", mocker.mock_open(read_data=json.dumps(suggestion_db_content))
-    )
-    mocker.patch.object(
-        mock_validated_db_path, "open", mocker.mock_open(read_data=json.dumps(validated_db_content))
-    )
+
+    # Write the test data to files
+    db_paths["suggestion"].write_text(json.dumps(suggestion_db_content), encoding="utf-8")
+    db_paths["validated"].write_text(json.dumps(validated_db_content), encoding="utf-8")
+
     db = ClassificationDatabase(
-        suggestion_db_path=mock_suggestion_db_path, validated_db_path=mock_validated_db_path
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
     )
     assert db.get_classification_count("sender@example.com", "Finance/Bloomberg") == 1
     assert db.get_classification_count("another@sender.com", "À Classer") == 5
     assert db.get_dominant_classification("validated@sender.com") == "Validated/Category"
 
 
-def test_update_suggestion_db(
-    mock_suggestion_db_path: MockerFixture,
-    mock_validated_db_path: MockerFixture,
-    mocker: MockerFixture,
-):
+def test_update_suggestion_db(db_paths):
     """Tests updating the suggestion database."""
-    mock_suggestion_db_path.exists.return_value = False
-    mock_validated_db_path.exists.return_value = False
     db = ClassificationDatabase(
-        suggestion_db_path=mock_suggestion_db_path, validated_db_path=mock_validated_db_path
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
     )
 
-    m = mocker.patch.object(mock_suggestion_db_path, "open", mocker.mock_open())
     db.update_suggestion("sender@example.com", "Finance/Bloomberg")
     assert db.get_classification_count("sender@example.com", "Finance/Bloomberg") == 1
 
     db.update_suggestion("sender@example.com", "Finance/Bloomberg")
     assert db.get_classification_count("sender@example.com", "Finance/Bloomberg") == 2
 
-    # Check that save was called twice
-    assert m.call_count == 2
+    # Verify persistence
+    assert db_paths["suggestion"].exists()
+    saved_data = json.loads(db_paths["suggestion"].read_text(encoding="utf-8"))
+    assert saved_data["sender@example.com"]["Finance/Bloomberg"] == 2
 
 
-def test_promote_to_validated(
-    mock_suggestion_db_path: MockerFixture, mock_validated_db_path: MockerFixture, mocker: MockerFixture
-):
+def test_promote_to_validated(db_paths):
     """Tests promoting a classification to the validated database."""
     suggestion_db_content = {"sender@example.com": {"Finance/Bloomberg": 1}}
-    mock_suggestion_db_path.exists.return_value = True
-    mock_validated_db_path.exists.return_value = False
-    mocker.patch.object(
-        mock_suggestion_db_path, "open", mocker.mock_open(read_data=json.dumps(suggestion_db_content))
-    )
-    db = ClassificationDatabase(
-        suggestion_db_path=mock_suggestion_db_path, validated_db_path=mock_validated_db_path
-    )
+    db_paths["suggestion"].write_text(json.dumps(suggestion_db_content), encoding="utf-8")
 
-    m_suggestion = mocker.patch.object(mock_suggestion_db_path, "open", mocker.mock_open())
-    m_validated = mocker.patch.object(mock_validated_db_path, "open", mocker.mock_open())
+    db = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
 
     db.promote_to_validated("sender@example.com", "Finance/Bloomberg")
 
     assert "sender@example.com" not in db.suggestion_db
     assert db.validated_db["sender@example.com"] == {"Finance/Bloomberg": 1}
-    assert m_suggestion.call_count == 1
-    assert m_validated.call_count == 1
+
+    # Verify persistence
+    saved_validated = json.loads(db_paths["validated"].read_text(encoding="utf-8"))
+    assert saved_validated["sender@example.com"] == {"Finance/Bloomberg": 1}
 
 
-def test_get_dominant_classification(
-    mock_suggestion_db_path: MockerFixture, mock_validated_db_path: MockerFixture, mocker: MockerFixture
-):
+def test_get_dominant_classification(db_paths):
     """Tests that the dominant classification is correctly retrieved."""
     suggestion_db_content = {"sender@example.com": {"Suggestion/Category": 5}}
     validated_db_content = {"sender@example.com": {"Validated/Category": 1}}
-    mock_suggestion_db_path.exists.return_value = True
-    mock_validated_db_path.exists.return_value = True
-    mocker.patch.object(
-        mock_suggestion_db_path, "open", mocker.mock_open(read_data=json.dumps(suggestion_db_content))
-    )
-    mocker.patch.object(
-        mock_validated_db_path, "open", mocker.mock_open(read_data=json.dumps(validated_db_content))
-    )
+
+    db_paths["suggestion"].write_text(json.dumps(suggestion_db_content), encoding="utf-8")
+    db_paths["validated"].write_text(json.dumps(validated_db_content), encoding="utf-8")
+
     db = ClassificationDatabase(
-        suggestion_db_path=mock_suggestion_db_path, validated_db_path=mock_validated_db_path
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
     )
 
+    # Validated DB takes priority
     assert db.get_dominant_classification("sender@example.com") == "Validated/Category"
     assert db.get_dominant_classification("new@sender.com") is None
+
+
+def test_domain_classification(db_paths):
+    """Tests domain classification functionality."""
+    db = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+
+    # Store a domain classification
+    db.store_domain_classification("example.com", "Services/Example")
+
+    # Retrieve it
+    assert db.get_category_by_domain("example.com") == "Services/Example"
+    assert db.get_category_by_domain("EXAMPLE.COM") == "Services/Example"  # Case insensitive
+    assert db.get_category_by_domain("unknown.com") is None
+
+    # Check email lookup
+    assert db.get_category_by_email("user@example.com") == "Services/Example"
+
+    # Check existence
+    assert db.has_domain_classification("example.com") is True
+    assert db.has_domain_classification("unknown.com") is False
+
+    # Remove
+    assert db.remove_domain_classification("example.com") is True
+    assert db.get_category_by_domain("example.com") is None
+
+
+def test_load_domain_db_with_content(db_paths):
+    """Tests loading domain database with existing content."""
+    domain_db_content = {"example.com": "Services/Example", "test.org": "Testing/Org"}
+    db_paths["domain"].write_text(json.dumps(domain_db_content), encoding="utf-8")
+
+    db = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+
+    assert db.get_category_by_domain("example.com") == "Services/Example"
+    assert db.get_category_by_domain("test.org") == "Testing/Org"
+
+
+def test_case_insensitive_sender_lookup(db_paths):
+    """Tests that sender lookups are case-insensitive."""
+    db = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+
+    db.update_suggestion("User@Example.COM", "Finance/Test")
+    assert db.get_classification_count("user@example.com", "Finance/Test") == 1
+    assert db.get_classification_count("USER@EXAMPLE.COM", "Finance/Test") == 1

--- a/tests/test_db_backup.py
+++ b/tests/test_db_backup.py
@@ -1,0 +1,174 @@
+"""Tests for database backup utilities."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mailtag.utils.db_backup import (
+    backup_all_databases,
+    backup_database,
+    cleanup_old_backups,
+    get_backup_stats,
+    list_backups,
+    restore_database,
+)
+
+
+@pytest.fixture
+def db_dir(tmp_path: Path) -> Path:
+    """Create a temporary db directory with sample databases."""
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+
+    # Create sample databases
+    sender_db = db_dir / "sender_classification_db.json"
+    sender_db.write_text(json.dumps({"test@example.com": {"Category": 1}}))
+
+    domain_db = db_dir / "domain_classifications.json"
+    domain_db.write_text(json.dumps({"example.com": "Category"}))
+
+    validated_db = db_dir / "validated_classification_db.json"
+    validated_db.write_text(json.dumps({}))
+
+    return db_dir
+
+
+class TestBackupDatabase:
+    def test_backup_creates_file(self, db_dir: Path):
+        """Test that backup creates a file."""
+        db_path = db_dir / "sender_classification_db.json"
+        backup_path = backup_database(db_path)
+
+        assert backup_path is not None
+        assert backup_path.exists()
+        assert backup_path.parent.name == "backups"
+
+    def test_backup_content_matches(self, db_dir: Path):
+        """Test that backup content matches original."""
+        db_path = db_dir / "sender_classification_db.json"
+        original_content = db_path.read_text()
+
+        backup_path = backup_database(db_path)
+
+        assert backup_path.read_text() == original_content
+
+    def test_backup_nonexistent_file(self, tmp_path: Path):
+        """Test that backing up nonexistent file returns None."""
+        db_path = tmp_path / "nonexistent.json"
+        result = backup_database(db_path)
+        assert result is None
+
+    def test_backup_custom_directory(self, db_dir: Path, tmp_path: Path):
+        """Test backup to custom directory."""
+        db_path = db_dir / "sender_classification_db.json"
+        custom_backup_dir = tmp_path / "custom_backups"
+
+        backup_path = backup_database(db_path, custom_backup_dir)
+
+        assert backup_path.parent == custom_backup_dir
+
+
+class TestBackupAllDatabases:
+    def test_backup_all(self, db_dir: Path):
+        """Test backing up all databases."""
+        backups = backup_all_databases(db_dir)
+
+        assert len(backups) == 3
+        backup_dir = db_dir / "backups"
+        assert backup_dir.exists()
+        assert len(list(backup_dir.glob("*.json"))) == 3
+
+
+class TestRestoreDatabase:
+    def test_restore_from_backup(self, db_dir: Path):
+        """Test restoring database from backup."""
+        db_path = db_dir / "sender_classification_db.json"
+        original_content = db_path.read_text()
+
+        backup_path = backup_database(db_path)
+
+        # Modify original
+        db_path.write_text(json.dumps({"modified": True}))
+
+        # Restore
+        restore_database(backup_path, db_path)
+
+        assert db_path.read_text() == original_content
+
+    def test_restore_nonexistent_backup(self, tmp_path: Path):
+        """Test restoring from nonexistent backup raises error."""
+        with pytest.raises(FileNotFoundError):
+            restore_database(tmp_path / "nonexistent.json", tmp_path / "db.json")
+
+
+class TestCleanupOldBackups:
+    def test_cleanup_keeps_recent(self, db_dir: Path):
+        """Test that cleanup keeps recent backups."""
+        # Create multiple backups
+        for _ in range(5):
+            backup_all_databases(db_dir)
+
+        backup_dir = db_dir / "backups"
+        deleted = cleanup_old_backups(backup_dir, keep_count=10)
+
+        assert deleted == 0
+
+    def test_cleanup_removes_excess(self, db_dir: Path):
+        """Test that cleanup removes excess backups."""
+        import time
+
+        backup_dir = db_dir / "backups"
+        backup_dir.mkdir(exist_ok=True)
+
+        # Create multiple backup files manually with different timestamps
+        for i in range(5):
+            filename = f"sender_classification_db_20251230_10000{i}.json"
+            (backup_dir / filename).write_text("{}")
+            time.sleep(0.01)  # Ensure different mtime
+
+        deleted = cleanup_old_backups(backup_dir, keep_count=2)
+
+        # Should keep 2, delete 3
+        assert deleted == 3
+        assert len(list(backup_dir.glob("*.json"))) == 2
+
+
+class TestListBackups:
+    def test_list_backups(self, db_dir: Path):
+        """Test listing backups."""
+        backup_all_databases(db_dir)
+
+        backup_dir = db_dir / "backups"
+        backups = list_backups(backup_dir)
+
+        assert len(backups) == 3
+        for backup in backups:
+            assert "path" in backup
+            assert "name" in backup
+            assert "size_bytes" in backup
+            assert "created" in backup
+
+    def test_list_empty_directory(self, tmp_path: Path):
+        """Test listing backups in empty directory."""
+        backups = list_backups(tmp_path)
+        assert backups == []
+
+
+class TestGetBackupStats:
+    def test_stats_with_backups(self, db_dir: Path):
+        """Test stats with backups."""
+        backup_all_databases(db_dir)
+
+        backup_dir = db_dir / "backups"
+        stats = get_backup_stats(backup_dir)
+
+        assert stats["total_backups"] == 3
+        assert stats["total_size_bytes"] > 0
+
+    def test_stats_empty_directory(self, tmp_path: Path):
+        """Test stats with no backups."""
+        stats = get_backup_stats(tmp_path)
+
+        assert stats["total_backups"] == 0
+        assert stats["oldest_backup"] is None

--- a/tests/test_domain_analyzer.py
+++ b/tests/test_domain_analyzer.py
@@ -308,7 +308,7 @@ class TestGenerateReport:
 
         # Count domain lines (exclude header/separator lines)
         lines = report.split("\n")
-        domain_lines = [l for l in lines if ".com" in l and not l.startswith("-")]
+        domain_lines = [line for line in lines if ".com" in line and not line.startswith("-")]
 
         # Should show at most 2 domains (or less if fewer candidates)
         assert len(domain_lines) <= 2

--- a/tests/test_filter_generator.py
+++ b/tests/test_filter_generator.py
@@ -17,11 +17,11 @@ def db_paths(tmp_path):
     }
 
 
-def test_generate_filters(db_paths):
-    """Tests the filter generation logic."""
+def test_generate_filters_no_consolidation(db_paths):
+    """Tests the filter generation logic without domain consolidation."""
     db_content = {
         "sender1@example.com": {"Finance/Bloomberg": 5, "À Classer": 1},
-        "sender2@example.com": {"Services/Apple": 10},
+        "sender2@other.com": {"Services/Apple": 10},
         "sender3@example.com": {},
     }
     db_paths["suggestion"].write_text(json.dumps(db_content), encoding="utf-8")
@@ -31,9 +31,13 @@ def test_generate_filters(db_paths):
         validated_db_path=db_paths["validated"],
         domain_db_path=db_paths["domain"],
     )
-    generator = FilterGenerator(database=database, output_path=db_paths["output"])
+    generator = FilterGenerator(
+        database=database,
+        output_path=db_paths["output"],
+        consolidate_domains=False,
+    )
 
-    generator.generate_filters()
+    count = generator.generate_filters()
 
     assert db_paths["output"].exists()
     written_content = db_paths["output"].read_text(encoding="utf-8")
@@ -41,10 +45,96 @@ def test_generate_filters(db_paths):
     # Perform some basic checks on the generated XML
     assert "sender1@example.com" in written_content
     assert "Finance/Bloomberg" in written_content
-    assert "sender2@example.com" in written_content
+    assert "sender2@other.com" in written_content
     assert "Services/Apple" in written_content
     # sender3 has no dominant category (empty dict)
     assert "sender3@example.com" not in written_content
+    assert count == 2
+
+
+def test_generate_filters_with_consolidation(db_paths):
+    """Tests domain consolidation for commercial domains."""
+    db_content = {
+        # Multiple senders from same commercial domain with same category
+        "sales@acme.com": {"Shopping/Retail": 5},
+        "support@acme.com": {"Shopping/Retail": 3},
+        "billing@acme.com": {"Shopping/Retail": 2},
+        # Another domain with same category
+        "info@other.com": {"Services/Online": 10},
+    }
+    db_paths["suggestion"].write_text(json.dumps(db_content), encoding="utf-8")
+
+    database = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+    generator = FilterGenerator(
+        database=database,
+        output_path=db_paths["output"],
+        consolidate_domains=True,
+        consolidation_threshold=2,
+    )
+
+    count = generator.generate_filters()
+
+    written_content = db_paths["output"].read_text(encoding="utf-8")
+
+    # acme.com should be consolidated into wildcard
+    assert "*@acme.com" in written_content
+    assert "sales@acme.com" not in written_content
+    assert "support@acme.com" not in written_content
+    assert "billing@acme.com" not in written_content
+
+    # other.com has only 1 sender, should remain individual
+    assert "info@other.com" in written_content
+    assert "*@other.com" not in written_content
+
+    # 2 entries: *@acme.com and info@other.com
+    assert count == 2
+
+
+def test_generate_filters_non_commercial_not_consolidated(db_paths):
+    """Tests that non-commercial domains (gmail, etc.) are never consolidated."""
+    db_content = {
+        # Multiple gmail addresses with same category
+        "user1@gmail.com": {"Contacts/Personal": 5},
+        "user2@gmail.com": {"Contacts/Personal": 3},
+        "user3@gmail.com": {"Contacts/Personal": 2},
+        # Commercial domain for comparison
+        "sales@company.com": {"Shopping/Retail": 5},
+        "support@company.com": {"Shopping/Retail": 3},
+    }
+    db_paths["suggestion"].write_text(json.dumps(db_content), encoding="utf-8")
+
+    database = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+    generator = FilterGenerator(
+        database=database,
+        output_path=db_paths["output"],
+        consolidate_domains=True,
+        consolidation_threshold=2,
+    )
+
+    count = generator.generate_filters()
+
+    written_content = db_paths["output"].read_text(encoding="utf-8")
+
+    # Gmail should NOT be consolidated - each user gets individual entry
+    assert "*@gmail.com" not in written_content
+    assert "user1@gmail.com" in written_content
+    assert "user2@gmail.com" in written_content
+    assert "user3@gmail.com" in written_content
+
+    # Commercial domain should be consolidated
+    assert "*@company.com" in written_content
+    assert "sales@company.com" not in written_content
+
+    # 4 entries: 3 gmail + 1 wildcard
+    assert count == 4
 
 
 def test_generate_filters_empty_db(db_paths):
@@ -56,17 +146,18 @@ def test_generate_filters_empty_db(db_paths):
     )
     generator = FilterGenerator(database=database, output_path=db_paths["output"])
 
-    generator.generate_filters()
+    count = generator.generate_filters()
 
     assert db_paths["output"].exists()
     written_content = db_paths["output"].read_text(encoding="utf-8")
     assert "<entry>" not in written_content
+    assert count == 0
 
 
 def test_generate_filters_with_validated(db_paths):
     """Tests filter generation with validated database entries."""
     suggestion_content = {"sender1@example.com": {"Finance/Bloomberg": 5}}
-    validated_content = {"sender2@example.com": {"Validated/Category": 1}}
+    validated_content = {"sender2@other.com": {"Validated/Category": 1}}
 
     db_paths["suggestion"].write_text(json.dumps(suggestion_content), encoding="utf-8")
     db_paths["validated"].write_text(json.dumps(validated_content), encoding="utf-8")
@@ -76,7 +167,11 @@ def test_generate_filters_with_validated(db_paths):
         validated_db_path=db_paths["validated"],
         domain_db_path=db_paths["domain"],
     )
-    generator = FilterGenerator(database=database, output_path=db_paths["output"])
+    generator = FilterGenerator(
+        database=database,
+        output_path=db_paths["output"],
+        consolidate_domains=False,
+    )
 
     generator.generate_filters()
 
@@ -85,5 +180,40 @@ def test_generate_filters_with_validated(db_paths):
     # Both suggestion and validated entries should be included
     assert "sender1@example.com" in written_content
     assert "Finance/Bloomberg" in written_content
-    assert "sender2@example.com" in written_content
+    assert "sender2@other.com" in written_content
     assert "Validated/Category" in written_content
+
+
+def test_generate_filters_different_categories_same_domain(db_paths):
+    """Tests that same domain with different categories creates separate entries."""
+    db_content = {
+        # Same domain but different categories - should not consolidate
+        "sales@acme.com": {"Shopping/Retail": 5},
+        "support@acme.com": {"Services/Support": 3},
+        "newsletter@acme.com": {"Shopping/Retail": 2},
+    }
+    db_paths["suggestion"].write_text(json.dumps(db_content), encoding="utf-8")
+
+    database = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+    generator = FilterGenerator(
+        database=database,
+        output_path=db_paths["output"],
+        consolidate_domains=True,
+        consolidation_threshold=2,
+    )
+
+    count = generator.generate_filters()
+
+    written_content = db_paths["output"].read_text(encoding="utf-8")
+
+    # Shopping/Retail has 2 senders (sales, newsletter) -> should consolidate
+    # Services/Support has 1 sender (support) -> should stay individual
+    assert "*@acme.com" in written_content  # For Shopping/Retail
+    assert "support@acme.com" in written_content  # Stays individual
+
+    # 2 entries: wildcard for Shopping/Retail + individual for Services/Support
+    assert count == 2

--- a/tests/test_filter_generator.py
+++ b/tests/test_filter_generator.py
@@ -1,61 +1,89 @@
 import json
-from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
 
+from mailtag.database import ClassificationDatabase
 from mailtag.filter_generator import FilterGenerator
 
 
 @pytest.fixture
-def mock_db_path(mocker: MockerFixture) -> MockerFixture:
-    """Fixture for a mocked database path."""
-    return mocker.MagicMock(spec=Path)
+def db_paths(tmp_path):
+    """Fixture providing temp paths for database files."""
+    return {
+        "suggestion": tmp_path / "suggestion_db.json",
+        "validated": tmp_path / "validated_db.json",
+        "domain": tmp_path / "domain_db.json",
+        "output": tmp_path / "mailfilter.xml",
+    }
 
 
-@pytest.fixture
-def mock_output_path(mocker: MockerFixture) -> MockerFixture:
-    """Fixture for a mocked output path."""
-    return mocker.MagicMock(spec=Path)
-
-
-def test_generate_filters(
-    mock_db_path: MockerFixture, mock_output_path: MockerFixture, mocker: MockerFixture
-):
+def test_generate_filters(db_paths):
     """Tests the filter generation logic."""
     db_content = {
         "sender1@example.com": {"Finance/Bloomberg": 5, "À Classer": 1},
         "sender2@example.com": {"Services/Apple": 10},
         "sender3@example.com": {},
     }
-    mock_db_path.exists.return_value = True
-    mocker.patch.object(mock_db_path, "open", mocker.mock_open(read_data=json.dumps(db_content)))
-    generator = FilterGenerator(db_path=mock_db_path, output_path=mock_output_path)
+    db_paths["suggestion"].write_text(json.dumps(db_content), encoding="utf-8")
 
-    m = mocker.patch.object(mock_output_path, "open", mocker.mock_open())
+    database = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+    generator = FilterGenerator(database=database, output_path=db_paths["output"])
+
     generator.generate_filters()
-    m.assert_called_once_with("w", encoding="utf-8")
 
-    # Get the content that was written to the file
-    written_content = m().write.call_args[0][0]
+    assert db_paths["output"].exists()
+    written_content = db_paths["output"].read_text(encoding="utf-8")
 
     # Perform some basic checks on the generated XML
     assert "sender1@example.com" in written_content
     assert "Finance/Bloomberg" in written_content
     assert "sender2@example.com" in written_content
     assert "Services/Apple" in written_content
+    # sender3 has no dominant category (empty dict)
     assert "sender3@example.com" not in written_content
 
 
-def test_generate_filters_empty_db(
-    mock_db_path: MockerFixture, mock_output_path: MockerFixture, mocker: MockerFixture
-):
+def test_generate_filters_empty_db(db_paths):
     """Tests filter generation with an empty database."""
-    mock_db_path.exists.return_value = False
-    generator = FilterGenerator(db_path=mock_db_path, output_path=mock_output_path)
+    database = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+    generator = FilterGenerator(database=database, output_path=db_paths["output"])
 
-    m = mocker.patch.object(mock_output_path, "open", mocker.mock_open())
     generator.generate_filters()
-    m.assert_called_once_with("w", encoding="utf-8")
-    written_content = m().write.call_args[0][0]
+
+    assert db_paths["output"].exists()
+    written_content = db_paths["output"].read_text(encoding="utf-8")
     assert "<entry>" not in written_content
+
+
+def test_generate_filters_with_validated(db_paths):
+    """Tests filter generation with validated database entries."""
+    suggestion_content = {"sender1@example.com": {"Finance/Bloomberg": 5}}
+    validated_content = {"sender2@example.com": {"Validated/Category": 1}}
+
+    db_paths["suggestion"].write_text(json.dumps(suggestion_content), encoding="utf-8")
+    db_paths["validated"].write_text(json.dumps(validated_content), encoding="utf-8")
+
+    database = ClassificationDatabase(
+        suggestion_db_path=db_paths["suggestion"],
+        validated_db_path=db_paths["validated"],
+        domain_db_path=db_paths["domain"],
+    )
+    generator = FilterGenerator(database=database, output_path=db_paths["output"])
+
+    generator.generate_filters()
+
+    written_content = db_paths["output"].read_text(encoding="utf-8")
+
+    # Both suggestion and validated entries should be included
+    assert "sender1@example.com" in written_content
+    assert "Finance/Bloomberg" in written_content
+    assert "sender2@example.com" in written_content
+    assert "Validated/Category" in written_content

--- a/tests/test_imap_service.py
+++ b/tests/test_imap_service.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 from email.header import Header
+from pathlib import Path
 
 import pytest
 from pytest_mock import MockerFixture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,15 @@ import pytest
 from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
-from mailtag.config import LoggingConfig
+from mailtag.config import (
+    ClassifierConfig,
+    FastParseConfig,
+    GeneralConfig,
+    GmailConfig,
+    ImapConfig,
+    LoggingConfig,
+    MLXConfig,
+)
 
 
 @pytest.fixture
@@ -10,9 +18,32 @@ def mock_app_config(mocker: MockerFixture):
     """Mocks the global CONFIG object in the main module."""
     mock_config = mocker.patch("main.CONFIG")
     mock_config.logging = LoggingConfig(level="INFO", file="test.log")
-    # Ensure providers are configured for tests that need them
-    mock_config.imap = mocker.MagicMock()
-    mock_config.gmail = mocker.MagicMock()
+    mock_config.general = GeneralConfig(
+        ollama_model="test-model",
+        api_base="http://localhost:11434",
+        use_imap_folders_for_classification=False,
+    )
+    mock_config.classifier = ClassifierConfig(
+        ai_confidence_threshold=0.7,
+        historical_confidence_threshold=0.9,
+        min_count=3,
+    )
+    mock_config.fast_parse = FastParseConfig(
+        batch_size=100,
+        folder_cache_ttl_hours=24,
+        unclassified_folder_name="Unclassified",
+        junk_folder_name="Junk",
+    )
+    mock_config.imap = ImapConfig(
+        host="imap.test.com",
+        user="test@test.com",
+        password="testpass",
+    )
+    mock_config.gmail = GmailConfig(
+        credentials_file="creds.json",
+        token_file="token.json",
+    )
+    mock_config.mlx = MLXConfig(enabled=False)
     return mock_config
 
 
@@ -33,8 +64,14 @@ class TestMain:
 
         runner = CliRunner()
         mock_run = mocker.patch("main.run_classification")
+        # Mock the provider classes to avoid actual IMAP/Gmail connections
+        mocker.patch("main.ImapService")
+        mocker.patch("main.GmailService")
+        # Mock refresh_imap_folders to avoid actual server calls
+        mocker.patch("main.refresh_imap_folders")
+
         result = runner.invoke(cli, ["run"])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"CLI failed with: {result.output}"
         assert mock_run.call_count == 2
 
     def test_main_provider_selection_gmail(self, mocker: MockerFixture, mock_app_config):
@@ -43,11 +80,12 @@ class TestMain:
 
         runner = CliRunner()
         mock_run = mocker.patch("main.run_classification")
+        # Patch at the module level where it's imported into main
+        mocker.patch("main.PROVIDER_CLASSES", {"gmail": mocker.MagicMock()})
+
         result = runner.invoke(cli, ["run", "--provider", "gmail"])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"CLI failed with: {result.output}"
         mock_run.assert_called_once()
-        provider, database, validate = mock_run.call_args[0]
-        assert provider.__class__.__name__ == "GmailService"
 
     def test_main_validate_mode(self, mocker: MockerFixture, mock_app_config):
         """
@@ -58,19 +96,24 @@ class TestMain:
 
         runner = CliRunner()
         mock_run = mocker.patch("main.run_classification")
+        # Mock the provider classes to avoid actual IMAP/Gmail connections
+        mocker.patch("main.ImapService")
+        mocker.patch("main.GmailService")
+        # Mock refresh_imap_folders to avoid actual server calls
+        mocker.patch("main.refresh_imap_folders")
+
         result = runner.invoke(cli, ["run", "--validate"])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"CLI failed with: {result.output}"
         assert mock_run.call_count == 2
-        provider, database, validate = mock_run.call_args[0]
-        assert validate is True
+        # Check that validate=True was passed
+        for call in mock_run.call_args_list:
+            args, kwargs = call
+            assert args[2] is True  # validate argument
 
     def test_main_invalid_provider(self, mocker: MockerFixture, mock_app_config):
         """Tests that the program exits with an error for an invalid provider."""
         from main import cli
 
         runner = CliRunner()
-        # Make sure no providers are configured to isolate the error
-        mock_app_config.imap = None
-        mock_app_config.gmail = None
         result = runner.invoke(cli, ["run", "--provider", "invalid"])
         assert result.exit_code != 0

--- a/tests/test_missing_google_deps.py
+++ b/tests/test_missing_google_deps.py
@@ -1,8 +1,8 @@
 import pytest
 
+import mailtag.gmail_auth as gmail_auth
 from mailtag.config import GmailConfig
 from mailtag.gmail_service import GmailService
-import mailtag.gmail_auth as gmail_auth
 
 
 def test_get_gmail_service_missing_dependencies(monkeypatch):
@@ -19,4 +19,3 @@ def test_gmail_service_connect_missing_dependencies(monkeypatch):
     with pytest.raises(ImportError, match="Google API dependencies are required"):
         with service.connect():
             pass
-

--- a/tests/test_mlx_provider.py
+++ b/tests/test_mlx_provider.py
@@ -35,9 +35,7 @@ class TestMLXEmbedder:
         mock_st.return_value = mock_model
 
         with patch.dict(sys.modules, {"sentence_transformers": MagicMock()}):
-            with patch(
-                "sentence_transformers.SentenceTransformer", mock_st
-            ):
+            with patch("sentence_transformers.SentenceTransformer", mock_st):
                 embedder = MLXEmbedder()
 
                 # Model not loaded yet - _model is None
@@ -115,11 +113,13 @@ class TestMLXEmbedder:
 
         # Create test embeddings
         query = np.array([1.0, 0.0, 0.0])
-        docs = np.array([
-            [1.0, 0.0, 0.0],  # Same as query
-            [0.0, 1.0, 0.0],  # Orthogonal
-            [0.707, 0.707, 0.0],  # 45 degrees
-        ])
+        docs = np.array(
+            [
+                [1.0, 0.0, 0.0],  # Same as query
+                [0.0, 1.0, 0.0],  # Orthogonal
+                [0.707, 0.707, 0.0],  # 45 degrees
+            ]
+        )
 
         similarities = embedder.similarity(query, docs)
 
@@ -255,9 +255,7 @@ class TestMLXLLM:
         llm._model = mock_model
         llm._tokenizer = mock_tokenizer
 
-        mock_generate = MagicMock(
-            return_value='{"category": "Test", "confidence": 1.5, "reason": ""}'
-        )
+        mock_generate = MagicMock(return_value='{"category": "Test", "confidence": 1.5, "reason": ""}')
         with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
             with patch("mlx_lm.generate", mock_generate):
                 _, confidence, _ = llm.classify("Test prompt")

--- a/tests/test_mlx_provider.py
+++ b/tests/test_mlx_provider.py
@@ -174,11 +174,16 @@ class TestMLXLLM:
         llm._model = mock_model
         llm._tokenizer = mock_tokenizer
 
-        # Patch mlx_lm.generate at module level before import
+        # Patch mlx_lm.generate and mlx_lm.sample_utils.make_sampler at module level
         mock_generate = MagicMock(return_value="  Generated response  ")
-        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
-            with patch("mlx_lm.generate", mock_generate):
-                result = llm.generate("Test prompt")
+        mock_make_sampler = MagicMock(return_value=MagicMock())
+        mock_sample_utils = MagicMock(make_sampler=mock_make_sampler)
+        mock_mlx_lm = MagicMock(generate=mock_generate, sample_utils=mock_sample_utils)
+        with patch.dict(
+            sys.modules,
+            {"mlx_lm": mock_mlx_lm, "mlx_lm.sample_utils": mock_sample_utils},
+        ):
+            result = llm.generate("Test prompt")
 
         assert result == "Generated response"  # Stripped
 
@@ -195,9 +200,14 @@ class TestMLXLLM:
 
         json_response = '{"category": "Commerce/Amazon", "confidence": 0.95, "reason": "test"}'
         mock_generate = MagicMock(return_value=json_response)
-        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
-            with patch("mlx_lm.generate", mock_generate):
-                category, confidence, reason = llm.classify("Test prompt")
+        mock_make_sampler = MagicMock(return_value=MagicMock())
+        mock_sample_utils = MagicMock(make_sampler=mock_make_sampler)
+        mock_mlx_lm = MagicMock(generate=mock_generate, sample_utils=mock_sample_utils)
+        with patch.dict(
+            sys.modules,
+            {"mlx_lm": mock_mlx_lm, "mlx_lm.sample_utils": mock_sample_utils},
+        ):
+            category, confidence, reason = llm.classify("Test prompt")
 
         assert category == "Commerce/Amazon"
         assert confidence == 0.95
@@ -216,9 +226,14 @@ class TestMLXLLM:
 
         response = 'I classify this as {"category": "Finance", "confidence": 0.8, "reason": "invoice"}'
         mock_generate = MagicMock(return_value=response)
-        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
-            with patch("mlx_lm.generate", mock_generate):
-                category, confidence, reason = llm.classify("Test prompt")
+        mock_make_sampler = MagicMock(return_value=MagicMock())
+        mock_sample_utils = MagicMock(make_sampler=mock_make_sampler)
+        mock_mlx_lm = MagicMock(generate=mock_generate, sample_utils=mock_sample_utils)
+        with patch.dict(
+            sys.modules,
+            {"mlx_lm": mock_mlx_lm, "mlx_lm.sample_utils": mock_sample_utils},
+        ):
+            category, confidence, reason = llm.classify("Test prompt")
 
         assert category == "Finance"
         assert confidence == 0.8
@@ -235,9 +250,14 @@ class TestMLXLLM:
         llm._tokenizer = mock_tokenizer
 
         mock_generate = MagicMock(return_value="Commerce/Amazon")
-        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
-            with patch("mlx_lm.generate", mock_generate):
-                category, confidence, reason = llm.classify("Test prompt")
+        mock_make_sampler = MagicMock(return_value=MagicMock())
+        mock_sample_utils = MagicMock(make_sampler=mock_make_sampler)
+        mock_mlx_lm = MagicMock(generate=mock_generate, sample_utils=mock_sample_utils)
+        with patch.dict(
+            sys.modules,
+            {"mlx_lm": mock_mlx_lm, "mlx_lm.sample_utils": mock_sample_utils},
+        ):
+            category, confidence, reason = llm.classify("Test prompt")
 
         # Fallback: raw response as category with low confidence
         assert category == "Commerce/Amazon"
@@ -256,9 +276,14 @@ class TestMLXLLM:
         llm._tokenizer = mock_tokenizer
 
         mock_generate = MagicMock(return_value='{"category": "Test", "confidence": 1.5, "reason": ""}')
-        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
-            with patch("mlx_lm.generate", mock_generate):
-                _, confidence, _ = llm.classify("Test prompt")
+        mock_make_sampler = MagicMock(return_value=MagicMock())
+        mock_sample_utils = MagicMock(make_sampler=mock_make_sampler)
+        mock_mlx_lm = MagicMock(generate=mock_generate, sample_utils=mock_sample_utils)
+        with patch.dict(
+            sys.modules,
+            {"mlx_lm": mock_mlx_lm, "mlx_lm.sample_utils": mock_sample_utils},
+        ):
+            _, confidence, _ = llm.classify("Test prompt")
 
         assert confidence == 1.0  # Clamped to max
 

--- a/tests/test_mlx_provider.py
+++ b/tests/test_mlx_provider.py
@@ -1,0 +1,304 @@
+"""Tests for MLX provider module."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+class TestMLXEmbedder:
+    """Test MLXEmbedder functionality."""
+
+    def test_init_default_model(self):
+        """Test initialization with default model."""
+        from mailtag.mlx_provider import MLXEmbedder
+
+        embedder = MLXEmbedder()
+        assert embedder.model_name == "nomic-ai/nomic-embed-text-v1.5"
+        assert embedder._model is None  # Lazy loaded
+
+    def test_init_custom_model(self):
+        """Test initialization with custom model."""
+        from mailtag.mlx_provider import MLXEmbedder
+
+        embedder = MLXEmbedder("custom-model/name")
+        assert embedder.model_name == "custom-model/name"
+
+    def test_model_lazy_loading(self):
+        """Test that model is lazy loaded."""
+        from mailtag.mlx_provider import MLXEmbedder
+
+        # Create mock SentenceTransformer
+        mock_st = MagicMock()
+        mock_model = MagicMock()
+        mock_st.return_value = mock_model
+
+        with patch.dict(sys.modules, {"sentence_transformers": MagicMock()}):
+            with patch(
+                "sentence_transformers.SentenceTransformer", mock_st
+            ):
+                embedder = MLXEmbedder()
+
+                # Model not loaded yet - _model is None
+                assert embedder._model is None
+
+    def test_encode_single_text(self):
+        """Test encoding a single text."""
+        from mailtag.mlx_provider import MLXEmbedder
+
+        embedder = MLXEmbedder()
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.array([[0.1, 0.2, 0.3]])
+        embedder._model = mock_model
+
+        result = embedder.encode("test text")
+
+        mock_model.encode.assert_called_once()
+        assert isinstance(result, np.ndarray)
+
+    def test_encode_adds_prefix_for_nomic(self):
+        """Test that nomic models get task prefixes."""
+        from mailtag.mlx_provider import MLXEmbedder
+
+        embedder = MLXEmbedder("nomic-ai/nomic-embed-text-v1.5")
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.array([[0.1, 0.2, 0.3]])
+        embedder._model = mock_model
+
+        embedder.encode("test", prefix="search_document: ")
+
+        # Check that prefix was added
+        call_args = mock_model.encode.call_args
+        texts = call_args[0][0]
+        assert texts[0].startswith("search_document: ")
+
+    def test_encode_query(self):
+        """Test encode_query uses correct prefix."""
+        from mailtag.mlx_provider import MLXEmbedder
+
+        embedder = MLXEmbedder()
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.array([[0.1, 0.2, 0.3]])
+        embedder._model = mock_model
+
+        result = embedder.encode_query("what is this?")
+
+        # Should use search_query prefix
+        call_args = mock_model.encode.call_args
+        texts = call_args[0][0]
+        assert texts[0].startswith("search_query: ")
+        assert result.shape == (3,)  # Single embedding
+
+    def test_encode_documents(self):
+        """Test encode_documents uses correct prefix."""
+        from mailtag.mlx_provider import MLXEmbedder
+
+        embedder = MLXEmbedder()
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+        embedder._model = mock_model
+
+        result = embedder.encode_documents(["doc1", "doc2"])
+
+        # Should use search_document prefix
+        call_args = mock_model.encode.call_args
+        texts = call_args[0][0]
+        assert all(t.startswith("search_document: ") for t in texts)
+        assert result.shape == (2, 3)
+
+    def test_similarity_computation(self):
+        """Test cosine similarity computation."""
+        from mailtag.mlx_provider import MLXEmbedder
+
+        embedder = MLXEmbedder()
+
+        # Create test embeddings
+        query = np.array([1.0, 0.0, 0.0])
+        docs = np.array([
+            [1.0, 0.0, 0.0],  # Same as query
+            [0.0, 1.0, 0.0],  # Orthogonal
+            [0.707, 0.707, 0.0],  # 45 degrees
+        ])
+
+        similarities = embedder.similarity(query, docs)
+
+        assert len(similarities) == 3
+        assert similarities[0] == pytest.approx(1.0, rel=1e-3)  # Same vector
+        assert similarities[1] == pytest.approx(0.0, rel=1e-3)  # Orthogonal
+        assert similarities[2] == pytest.approx(0.707, rel=1e-2)  # 45 degrees
+
+
+class TestMLXLLM:
+    """Test MLXLLM functionality."""
+
+    def test_init_default_model(self):
+        """Test initialization with default model."""
+        from mailtag.mlx_provider import MLXLLM
+
+        llm = MLXLLM()
+        assert llm.model_name == "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
+        assert llm.max_tokens == 256
+        assert llm.temperature == 0.2
+        assert llm._model is None
+
+    def test_init_custom_params(self):
+        """Test initialization with custom parameters."""
+        from mailtag.mlx_provider import MLXLLM
+
+        llm = MLXLLM(
+            model_name="custom/model",
+            max_tokens=512,
+            temperature=0.5,
+        )
+        assert llm.model_name == "custom/model"
+        assert llm.max_tokens == 512
+        assert llm.temperature == 0.5
+
+    def test_model_lazy_loading(self):
+        """Test that model is lazy loaded."""
+        from mailtag.mlx_provider import MLXLLM
+
+        llm = MLXLLM()
+        # Model not loaded yet - _model is None
+        assert llm._model is None
+
+    def test_generate_basic(self):
+        """Test basic text generation."""
+        from mailtag.mlx_provider import MLXLLM
+
+        llm = MLXLLM()
+        mock_model = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "formatted prompt"
+        llm._model = mock_model
+        llm._tokenizer = mock_tokenizer
+
+        # Patch mlx_lm.generate at module level before import
+        mock_generate = MagicMock(return_value="  Generated response  ")
+        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
+            with patch("mlx_lm.generate", mock_generate):
+                result = llm.generate("Test prompt")
+
+        assert result == "Generated response"  # Stripped
+
+    def test_classify_json_response(self):
+        """Test classification with JSON response."""
+        from mailtag.mlx_provider import MLXLLM
+
+        llm = MLXLLM()
+        mock_model = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "formatted prompt"
+        llm._model = mock_model
+        llm._tokenizer = mock_tokenizer
+
+        json_response = '{"category": "Commerce/Amazon", "confidence": 0.95, "reason": "test"}'
+        mock_generate = MagicMock(return_value=json_response)
+        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
+            with patch("mlx_lm.generate", mock_generate):
+                category, confidence, reason = llm.classify("Test prompt")
+
+        assert category == "Commerce/Amazon"
+        assert confidence == 0.95
+        assert reason == "test"
+
+    def test_classify_json_in_text(self):
+        """Test classification with JSON embedded in text."""
+        from mailtag.mlx_provider import MLXLLM
+
+        llm = MLXLLM()
+        mock_model = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "formatted prompt"
+        llm._model = mock_model
+        llm._tokenizer = mock_tokenizer
+
+        response = 'I classify this as {"category": "Finance", "confidence": 0.8, "reason": "invoice"}'
+        mock_generate = MagicMock(return_value=response)
+        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
+            with patch("mlx_lm.generate", mock_generate):
+                category, confidence, reason = llm.classify("Test prompt")
+
+        assert category == "Finance"
+        assert confidence == 0.8
+
+    def test_classify_invalid_json(self):
+        """Test classification with invalid JSON response."""
+        from mailtag.mlx_provider import MLXLLM
+
+        llm = MLXLLM()
+        mock_model = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "formatted prompt"
+        llm._model = mock_model
+        llm._tokenizer = mock_tokenizer
+
+        mock_generate = MagicMock(return_value="Commerce/Amazon")
+        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
+            with patch("mlx_lm.generate", mock_generate):
+                category, confidence, reason = llm.classify("Test prompt")
+
+        # Fallback: raw response as category with low confidence
+        assert category == "Commerce/Amazon"
+        assert confidence == 0.5
+        assert reason == "JSON parsing failed"
+
+    def test_classify_confidence_clamping(self):
+        """Test that confidence is clamped to [0, 1]."""
+        from mailtag.mlx_provider import MLXLLM
+
+        llm = MLXLLM()
+        mock_model = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "formatted prompt"
+        llm._model = mock_model
+        llm._tokenizer = mock_tokenizer
+
+        mock_generate = MagicMock(
+            return_value='{"category": "Test", "confidence": 1.5, "reason": ""}'
+        )
+        with patch.dict(sys.modules, {"mlx_lm": MagicMock(generate=mock_generate)}):
+            with patch("mlx_lm.generate", mock_generate):
+                _, confidence, _ = llm.classify("Test prompt")
+
+        assert confidence == 1.0  # Clamped to max
+
+
+class TestFactoryFunctions:
+    """Test factory functions."""
+
+    def test_get_embedder_default(self):
+        """Test get_embedder with default model."""
+        from mailtag.mlx_provider import get_embedder
+
+        embedder = get_embedder()
+        assert embedder.model_name == "nomic-ai/nomic-embed-text-v1.5"
+
+    def test_get_embedder_custom(self):
+        """Test get_embedder with custom model."""
+        from mailtag.mlx_provider import get_embedder
+
+        embedder = get_embedder("custom-model")
+        assert embedder.model_name == "custom-model"
+
+    def test_get_llm_default(self):
+        """Test get_llm with default parameters."""
+        from mailtag.mlx_provider import get_llm
+
+        llm = get_llm()
+        assert llm.max_tokens == 256
+        assert llm.temperature == 0.2
+
+    def test_get_llm_custom(self):
+        """Test get_llm with custom parameters."""
+        from mailtag.mlx_provider import get_llm
+
+        llm = get_llm(
+            model_name="custom/model",
+            max_tokens=512,
+            temperature=0.7,
+        )
+        assert llm.model_name == "custom/model"
+        assert llm.max_tokens == 512
+        assert llm.temperature == 0.7

--- a/tests/test_semantic_router.py
+++ b/tests/test_semantic_router.py
@@ -1,0 +1,358 @@
+"""Tests for SemanticRouter module."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+class TestSemanticRouter:
+    """Test SemanticRouter functionality."""
+
+    @pytest.fixture
+    def mock_embedder(self):
+        """Create a mock embedder."""
+        embedder = MagicMock()
+        embedder.encode_documents.return_value = np.array([
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ])
+        embedder.encode_query.return_value = np.array([0.9, 0.1, 0.0])
+        return embedder
+
+    def test_init_default_threshold(self, mock_embedder):
+        """Test initialization with default threshold."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        assert router.score_threshold == 0.75
+        assert router.categories == []
+        assert router._embedding_matrix is None
+
+    def test_init_custom_threshold(self, mock_embedder):
+        """Test initialization with custom threshold."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder, score_threshold=0.9)
+        assert router.score_threshold == 0.9
+
+    def test_build_from_examples(self, mock_embedder):
+        """Test building embeddings from examples."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+
+        examples = {
+            "Commerce": ["shopping email", "order confirmation"],
+            "Finance": ["invoice", "payment"],
+            "Travel": ["flight booking", "hotel reservation"],
+        }
+
+        router.build_from_examples(examples)
+
+        assert len(router.categories) == 3
+        assert "Commerce" in router.categories
+        assert "Finance" in router.categories
+        assert "Travel" in router.categories
+        assert router._embedding_matrix is not None
+
+    def test_build_from_examples_empty_skipped(self, mock_embedder):
+        """Test that empty categories are skipped."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+
+        examples = {
+            "Valid": ["example1", "example2"],
+            "Empty": [],  # Should be skipped
+        }
+
+        router.build_from_examples(examples)
+
+        assert len(router.categories) == 1
+        assert "Valid" in router.categories
+        assert "Empty" not in router.categories
+
+    def test_route_finds_best_match(self, mock_embedder):
+        """Test that routing finds the best matching category."""
+        from mailtag.semantic_router import SemanticRouter
+
+        # Setup embedder to return specific embeddings
+        mock_embedder.encode_documents.return_value = np.array([
+            [1.0, 0.0, 0.0],  # Commerce
+            [0.0, 1.0, 0.0],  # Finance
+            [0.0, 0.0, 1.0],  # Travel
+        ])
+        # Query embedding is close to Commerce
+        mock_embedder.encode_query.return_value = np.array([0.95, 0.05, 0.0])
+
+        router = SemanticRouter(mock_embedder, score_threshold=0.5)
+        router.build_from_examples({
+            "Commerce": ["shopping"],
+            "Finance": ["banking"],
+            "Travel": ["flights"],
+        })
+
+        category, score = router.route("shopping related query")
+
+        assert category == "Commerce"
+        assert score > 0.5
+
+    def test_route_below_threshold_returns_empty(self, mock_embedder):
+        """Test that routing below threshold returns empty."""
+        from mailtag.semantic_router import SemanticRouter
+
+        # Setup embedder with orthogonal embeddings
+        mock_embedder.encode_documents.return_value = np.array([
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ])
+        # Query embedding is not close to any category
+        mock_embedder.encode_query.return_value = np.array([0.3, 0.3, 0.9])
+
+        router = SemanticRouter(mock_embedder, score_threshold=0.75)
+        router.build_from_examples({
+            "Cat1": ["example1"],
+            "Cat2": ["example2"],
+        })
+
+        category, score = router.route("unrelated query")
+
+        assert category == ""
+        assert score < 0.75
+
+    def test_route_no_categories_returns_empty(self, mock_embedder):
+        """Test routing with no categories loaded."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+
+        category, score = router.route("any query")
+
+        assert category == ""
+        assert score == 0.0
+
+    def test_route_with_alternatives(self, mock_embedder):
+        """Test getting top-k alternatives."""
+        from mailtag.semantic_router import SemanticRouter
+
+        # Setup embeddings
+        mock_embedder.encode_documents.return_value = np.array([
+            [1.0, 0.0, 0.0],
+            [0.9, 0.1, 0.0],
+            [0.0, 1.0, 0.0],
+        ])
+        mock_embedder.encode_query.return_value = np.array([0.95, 0.05, 0.0])
+
+        router = SemanticRouter(mock_embedder)
+        router.build_from_examples({
+            "Cat1": ["ex1"],
+            "Cat2": ["ex2"],
+            "Cat3": ["ex3"],
+        })
+
+        alternatives = router.route_with_alternatives("query", top_k=2)
+
+        assert len(alternatives) == 2
+        assert all(isinstance(alt, tuple) for alt in alternatives)
+        assert all(len(alt) == 2 for alt in alternatives)
+        # Results should be sorted by score descending
+        assert alternatives[0][1] >= alternatives[1][1]
+
+    def test_add_category(self, mock_embedder):
+        """Test adding a new category."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        router.build_from_examples({"Existing": ["example"]})
+
+        assert "Existing" in router.categories
+        assert "NewCat" not in router.categories
+
+        mock_embedder.encode_documents.return_value = np.array([[0.5, 0.5, 0.0]])
+        router.add_category("NewCat", ["new example"])
+
+        assert "NewCat" in router.categories
+        assert router.num_categories == 2
+
+    def test_add_category_empty_examples_ignored(self, mock_embedder):
+        """Test that adding category with empty examples is ignored."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        initial_count = router.num_categories
+
+        router.add_category("Empty", [])
+
+        assert router.num_categories == initial_count
+
+    def test_remove_category(self, mock_embedder):
+        """Test removing a category."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        router.build_from_examples({
+            "Cat1": ["ex1"],
+            "Cat2": ["ex2"],
+        })
+
+        assert "Cat1" in router.categories
+        result = router.remove_category("Cat1")
+
+        assert result is True
+        assert "Cat1" not in router.categories
+        assert router.num_categories == 1
+
+    def test_remove_nonexistent_category(self, mock_embedder):
+        """Test removing a non-existent category."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        result = router.remove_category("NonExistent")
+
+        assert result is False
+
+    def test_save_and_load_embeddings(self, mock_embedder):
+        """Test saving and loading embeddings."""
+        from mailtag.semantic_router import SemanticRouter
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "embeddings.npz"
+
+            # Build and save
+            router1 = SemanticRouter(mock_embedder)
+            router1.build_from_examples({
+                "Cat1": ["ex1"],
+                "Cat2": ["ex2"],
+            })
+            save_result = router1.save_embeddings(filepath)
+
+            assert save_result is True
+            assert filepath.exists()
+
+            # Load in new router
+            router2 = SemanticRouter(mock_embedder)
+            load_result = router2.load_embeddings(filepath)
+
+            assert load_result is True
+            assert router2.num_categories == router1.num_categories
+            assert set(router2.categories) == set(router1.categories)
+
+    def test_load_nonexistent_file(self, mock_embedder):
+        """Test loading from non-existent file."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        result = router.load_embeddings(Path("/nonexistent/path.npz"))
+
+        assert result is False
+        assert router.num_categories == 0
+
+    def test_num_categories_property(self, mock_embedder):
+        """Test num_categories property."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        assert router.num_categories == 0
+
+        router.build_from_examples({
+            "Cat1": ["ex1"],
+            "Cat2": ["ex2"],
+            "Cat3": ["ex3"],
+        })
+        assert router.num_categories == 3
+
+    def test_get_category_info(self, mock_embedder):
+        """Test getting category info."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        router.build_from_examples({
+            "Cat1": ["ex1"],
+            "Cat2": ["ex2"],
+        })
+
+        info = router.get_category_info()
+
+        assert "Cat1" in info
+        assert "Cat2" in info
+        assert "embedding_dim" in info["Cat1"]
+        assert info["Cat1"]["embedding_dim"] == 3
+
+    def test_build_from_validated_db(self, mock_embedder):
+        """Test building from validated database."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+
+        validated_db = {
+            "user@amazon.com": "Commerce/Amazon",
+            "orders@amazon.com": "Commerce/Amazon",
+            "info@bank.com": "Finance/Banking",
+            "single@test.com": "OneEmail",  # Only 1 example
+        }
+
+        router.build_from_validated_db(validated_db, min_examples=1)
+
+        assert "Commerce/Amazon" in router.categories
+        assert "Finance/Banking" in router.categories
+        assert "OneEmail" in router.categories
+
+    def test_build_from_validated_db_min_examples(self, mock_embedder):
+        """Test that min_examples filter works."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+
+        validated_db = {
+            "user@amazon.com": "Commerce/Amazon",
+            "orders@amazon.com": "Commerce/Amazon",
+            "single@test.com": "OneEmail",  # Only 1 example
+        }
+
+        router.build_from_validated_db(validated_db, min_examples=2)
+
+        assert "Commerce/Amazon" in router.categories
+        assert "OneEmail" not in router.categories  # Filtered out
+
+
+class TestSemanticRouterEmbeddingMatrix:
+    """Test embedding matrix operations."""
+
+    @pytest.fixture
+    def mock_embedder(self):
+        """Create a mock embedder."""
+        embedder = MagicMock()
+        return embedder
+
+    def test_embedding_matrix_normalized(self, mock_embedder):
+        """Test that embedding matrix is normalized."""
+        from mailtag.semantic_router import SemanticRouter
+
+        # Return non-normalized embeddings
+        mock_embedder.encode_documents.return_value = np.array([
+            [3.0, 4.0, 0.0],  # Norm = 5
+            [0.0, 2.0, 0.0],  # Norm = 2
+        ])
+
+        router = SemanticRouter(mock_embedder)
+        router.build_from_examples({
+            "Cat1": ["ex1"],
+            "Cat2": ["ex2"],
+        })
+
+        # Check that rows are normalized
+        norms = np.linalg.norm(router._embedding_matrix, axis=1)
+        np.testing.assert_array_almost_equal(norms, [1.0, 1.0])
+
+    def test_empty_embeddings_no_matrix(self, mock_embedder):
+        """Test that empty embeddings result in no matrix."""
+        from mailtag.semantic_router import SemanticRouter
+
+        router = SemanticRouter(mock_embedder)
+        router._build_embedding_matrix()
+
+        assert router._embedding_matrix is None

--- a/tests/test_semantic_router.py
+++ b/tests/test_semantic_router.py
@@ -15,11 +15,13 @@ class TestSemanticRouter:
     def mock_embedder(self):
         """Create a mock embedder."""
         embedder = MagicMock()
-        embedder.encode_documents.return_value = np.array([
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0],
-        ])
+        embedder.encode_documents.return_value = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
         embedder.encode_query.return_value = np.array([0.9, 0.1, 0.0])
         return embedder
 
@@ -81,20 +83,24 @@ class TestSemanticRouter:
         from mailtag.semantic_router import SemanticRouter
 
         # Setup embedder to return specific embeddings
-        mock_embedder.encode_documents.return_value = np.array([
-            [1.0, 0.0, 0.0],  # Commerce
-            [0.0, 1.0, 0.0],  # Finance
-            [0.0, 0.0, 1.0],  # Travel
-        ])
+        mock_embedder.encode_documents.return_value = np.array(
+            [
+                [1.0, 0.0, 0.0],  # Commerce
+                [0.0, 1.0, 0.0],  # Finance
+                [0.0, 0.0, 1.0],  # Travel
+            ]
+        )
         # Query embedding is close to Commerce
         mock_embedder.encode_query.return_value = np.array([0.95, 0.05, 0.0])
 
         router = SemanticRouter(mock_embedder, score_threshold=0.5)
-        router.build_from_examples({
-            "Commerce": ["shopping"],
-            "Finance": ["banking"],
-            "Travel": ["flights"],
-        })
+        router.build_from_examples(
+            {
+                "Commerce": ["shopping"],
+                "Finance": ["banking"],
+                "Travel": ["flights"],
+            }
+        )
 
         category, score = router.route("shopping related query")
 
@@ -106,18 +112,22 @@ class TestSemanticRouter:
         from mailtag.semantic_router import SemanticRouter
 
         # Setup embedder with orthogonal embeddings
-        mock_embedder.encode_documents.return_value = np.array([
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-        ])
+        mock_embedder.encode_documents.return_value = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
         # Query embedding is not close to any category
         mock_embedder.encode_query.return_value = np.array([0.3, 0.3, 0.9])
 
         router = SemanticRouter(mock_embedder, score_threshold=0.75)
-        router.build_from_examples({
-            "Cat1": ["example1"],
-            "Cat2": ["example2"],
-        })
+        router.build_from_examples(
+            {
+                "Cat1": ["example1"],
+                "Cat2": ["example2"],
+            }
+        )
 
         category, score = router.route("unrelated query")
 
@@ -140,19 +150,23 @@ class TestSemanticRouter:
         from mailtag.semantic_router import SemanticRouter
 
         # Setup embeddings
-        mock_embedder.encode_documents.return_value = np.array([
-            [1.0, 0.0, 0.0],
-            [0.9, 0.1, 0.0],
-            [0.0, 1.0, 0.0],
-        ])
+        mock_embedder.encode_documents.return_value = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.9, 0.1, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
         mock_embedder.encode_query.return_value = np.array([0.95, 0.05, 0.0])
 
         router = SemanticRouter(mock_embedder)
-        router.build_from_examples({
-            "Cat1": ["ex1"],
-            "Cat2": ["ex2"],
-            "Cat3": ["ex3"],
-        })
+        router.build_from_examples(
+            {
+                "Cat1": ["ex1"],
+                "Cat2": ["ex2"],
+                "Cat3": ["ex3"],
+            }
+        )
 
         alternatives = router.route_with_alternatives("query", top_k=2)
 
@@ -194,10 +208,12 @@ class TestSemanticRouter:
         from mailtag.semantic_router import SemanticRouter
 
         router = SemanticRouter(mock_embedder)
-        router.build_from_examples({
-            "Cat1": ["ex1"],
-            "Cat2": ["ex2"],
-        })
+        router.build_from_examples(
+            {
+                "Cat1": ["ex1"],
+                "Cat2": ["ex2"],
+            }
+        )
 
         assert "Cat1" in router.categories
         result = router.remove_category("Cat1")
@@ -224,10 +240,12 @@ class TestSemanticRouter:
 
             # Build and save
             router1 = SemanticRouter(mock_embedder)
-            router1.build_from_examples({
-                "Cat1": ["ex1"],
-                "Cat2": ["ex2"],
-            })
+            router1.build_from_examples(
+                {
+                    "Cat1": ["ex1"],
+                    "Cat2": ["ex2"],
+                }
+            )
             save_result = router1.save_embeddings(filepath)
 
             assert save_result is True
@@ -258,11 +276,13 @@ class TestSemanticRouter:
         router = SemanticRouter(mock_embedder)
         assert router.num_categories == 0
 
-        router.build_from_examples({
-            "Cat1": ["ex1"],
-            "Cat2": ["ex2"],
-            "Cat3": ["ex3"],
-        })
+        router.build_from_examples(
+            {
+                "Cat1": ["ex1"],
+                "Cat2": ["ex2"],
+                "Cat3": ["ex3"],
+            }
+        )
         assert router.num_categories == 3
 
     def test_get_category_info(self, mock_embedder):
@@ -270,10 +290,12 @@ class TestSemanticRouter:
         from mailtag.semantic_router import SemanticRouter
 
         router = SemanticRouter(mock_embedder)
-        router.build_from_examples({
-            "Cat1": ["ex1"],
-            "Cat2": ["ex2"],
-        })
+        router.build_from_examples(
+            {
+                "Cat1": ["ex1"],
+                "Cat2": ["ex2"],
+            }
+        )
 
         info = router.get_category_info()
 
@@ -333,16 +355,20 @@ class TestSemanticRouterEmbeddingMatrix:
         from mailtag.semantic_router import SemanticRouter
 
         # Return non-normalized embeddings
-        mock_embedder.encode_documents.return_value = np.array([
-            [3.0, 4.0, 0.0],  # Norm = 5
-            [0.0, 2.0, 0.0],  # Norm = 2
-        ])
+        mock_embedder.encode_documents.return_value = np.array(
+            [
+                [3.0, 4.0, 0.0],  # Norm = 5
+                [0.0, 2.0, 0.0],  # Norm = 2
+            ]
+        )
 
         router = SemanticRouter(mock_embedder)
-        router.build_from_examples({
-            "Cat1": ["ex1"],
-            "Cat2": ["ex2"],
-        })
+        router.build_from_examples(
+            {
+                "Cat1": ["ex1"],
+                "Cat2": ["ex2"],
+            }
+        )
 
         # Check that rows are normalized
         norms = np.linalg.norm(router._embedding_matrix, axis=1)

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,7 +1,5 @@
 """Tests for text processing utilities."""
 
-import pytest
-
 from mailtag.utils.text_utils import (
     _remove_signatures,
     clean_whitespace,
@@ -339,7 +337,11 @@ class TestIsLikelyAutomated:
         assert is_likely_automated(body, subject) is False  # Only 1 indicator
 
         # Add more indicators
-        body = "Newsletter with https://link1.com and https://link2.com and https://link3.com and https://link4.com and https://link5.com and https://link6.com. Unsubscribe here."
+        body = (
+            "Newsletter with https://link1.com and https://link2.com and "
+            "https://link3.com and https://link4.com and https://link5.com and "
+            "https://link6.com. Unsubscribe here."
+        )
         assert is_likely_automated(body, subject) is True  # 2+ indicators
 
     def test_is_automated_noreply(self):

--- a/uv.lock
+++ b/uv.lock
@@ -291,6 +291,15 @@ wheels = [
 ]
 
 [[package]]
+name = "einops"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/81/df4fbe24dff8ba3934af99044188e20a98ed441ad17a274539b74e82e126/einops-0.8.1.tar.gz", hash = "sha256:de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84", size = 54805, upload-time = "2025-02-09T03:17:00.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl", hash = "sha256:919387eb55330f5757c6bea9165c5ff5cfe63a642682ea788a6d472576d81737", size = 64359, upload-time = "2025-02-09T03:17:01.998Z" },
+]
+
+[[package]]
 name = "faker"
 version = "38.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -611,6 +620,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "click" },
     { name = "dotenv" },
+    { name = "einops" },
     { name = "fastapi" },
     { name = "google" },
     { name = "google-api-python-client" },
@@ -659,6 +669,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "click", specifier = ">=8.2.1" },
     { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "einops", specifier = ">=0.8.1" },
     { name = "faker", marker = "extra == 'dev'" },
     { name = "fastapi", specifier = ">=0.115.14" },
     { name = "google", specifier = ">=3.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -7,113 +7,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "aiohappyeyeballs"
-version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
-]
-
-[[package]]
-name = "aiohttp"
-version = "3.13.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ce/3b83ebba6b3207a7135e5fcaba49706f8a4b6008153b4e30540c982fae26/aiohttp-3.13.2.tar.gz", hash = "sha256:40176a52c186aefef6eb3cad2cdd30cd06e3afbe88fe8ab2af9c0b90f228daca", size = 7837994, upload-time = "2025-10-28T20:59:39.937Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/9b/01f00e9856d0a73260e86dd8ed0c2234a466c5c1712ce1c281548df39777/aiohttp-3.13.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b1e56bab2e12b2b9ed300218c351ee2a3d8c8fdab5b1ec6193e11a817767e47b", size = 737623, upload-time = "2025-10-28T20:56:30.797Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/1b/4be39c445e2b2bd0aab4ba736deb649fabf14f6757f405f0c9685019b9e9/aiohttp-3.13.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:364e25edaabd3d37b1db1f0cbcee8c73c9a3727bfa262b83e5e4cf3489a2a9dc", size = 492664, upload-time = "2025-10-28T20:56:32.708Z" },
-    { url = "https://files.pythonhosted.org/packages/28/66/d35dcfea8050e131cdd731dff36434390479b4045a8d0b9d7111b0a968f1/aiohttp-3.13.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c5c94825f744694c4b8db20b71dba9a257cd2ba8e010a803042123f3a25d50d7", size = 491808, upload-time = "2025-10-28T20:56:34.57Z" },
-    { url = "https://files.pythonhosted.org/packages/00/29/8e4609b93e10a853b65f8291e64985de66d4f5848c5637cddc70e98f01f8/aiohttp-3.13.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba2715d842ffa787be87cbfce150d5e88c87a98e0b62e0f5aa489169a393dbbb", size = 1738863, upload-time = "2025-10-28T20:56:36.377Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/fa/4ebdf4adcc0def75ced1a0d2d227577cd7b1b85beb7edad85fcc87693c75/aiohttp-3.13.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:585542825c4bc662221fb257889e011a5aa00f1ae4d75d1d246a5225289183e3", size = 1700586, upload-time = "2025-10-28T20:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/da/04/73f5f02ff348a3558763ff6abe99c223381b0bace05cd4530a0258e52597/aiohttp-3.13.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:39d02cb6025fe1aabca329c5632f48c9532a3dabccd859e7e2f110668972331f", size = 1768625, upload-time = "2025-10-28T20:56:39.75Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/49/a825b79ffec124317265ca7d2344a86bcffeb960743487cb11988ffb3494/aiohttp-3.13.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e67446b19e014d37342f7195f592a2a948141d15a312fe0e700c2fd2f03124f6", size = 1867281, upload-time = "2025-10-28T20:56:41.471Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/48/adf56e05f81eac31edcfae45c90928f4ad50ef2e3ea72cb8376162a368f8/aiohttp-3.13.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4356474ad6333e41ccefd39eae869ba15a6c5299c9c01dfdcfdd5c107be4363e", size = 1752431, upload-time = "2025-10-28T20:56:43.162Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ab/593855356eead019a74e862f21523db09c27f12fd24af72dbc3555b9bfd9/aiohttp-3.13.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eeacf451c99b4525f700f078becff32c32ec327b10dcf31306a8a52d78166de7", size = 1562846, upload-time = "2025-10-28T20:56:44.85Z" },
-    { url = "https://files.pythonhosted.org/packages/39/0f/9f3d32271aa8dc35036e9668e31870a9d3b9542dd6b3e2c8a30931cb27ae/aiohttp-3.13.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d8a9b889aeabd7a4e9af0b7f4ab5ad94d42e7ff679aaec6d0db21e3b639ad58d", size = 1699606, upload-time = "2025-10-28T20:56:46.519Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/3c/52d2658c5699b6ef7692a3f7128b2d2d4d9775f2a68093f74bca06cf01e1/aiohttp-3.13.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:fa89cb11bc71a63b69568d5b8a25c3ca25b6d54c15f907ca1c130d72f320b76b", size = 1720663, upload-time = "2025-10-28T20:56:48.528Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/d4/8f8f3ff1fb7fb9e3f04fcad4e89d8a1cd8fc7d05de67e3de5b15b33008ff/aiohttp-3.13.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8aa7c807df234f693fed0ecd507192fc97692e61fee5702cdc11155d2e5cadc8", size = 1737939, upload-time = "2025-10-28T20:56:50.77Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d3/ddd348f8a27a634daae39a1b8e291ff19c77867af438af844bf8b7e3231b/aiohttp-3.13.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9eb3e33fdbe43f88c3c75fa608c25e7c47bbd80f48d012763cb67c47f39a7e16", size = 1555132, upload-time = "2025-10-28T20:56:52.568Z" },
-    { url = "https://files.pythonhosted.org/packages/39/b8/46790692dc46218406f94374903ba47552f2f9f90dad554eed61bfb7b64c/aiohttp-3.13.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9434bc0d80076138ea986833156c5a48c9c7a8abb0c96039ddbb4afc93184169", size = 1764802, upload-time = "2025-10-28T20:56:54.292Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/e4/19ce547b58ab2a385e5f0b8aa3db38674785085abcf79b6e0edd1632b12f/aiohttp-3.13.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ff15c147b2ad66da1f2cbb0622313f2242d8e6e8f9b79b5206c84523a4473248", size = 1719512, upload-time = "2025-10-28T20:56:56.428Z" },
-    { url = "https://files.pythonhosted.org/packages/70/30/6355a737fed29dcb6dfdd48682d5790cb5eab050f7b4e01f49b121d3acad/aiohttp-3.13.2-cp312-cp312-win32.whl", hash = "sha256:27e569eb9d9e95dbd55c0fc3ec3a9335defbf1d8bc1d20171a49f3c4c607b93e", size = 426690, upload-time = "2025-10-28T20:56:58.736Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/b10ac09069973d112de6ef980c1f6bb31cb7dcd0bc363acbdad58f927873/aiohttp-3.13.2-cp312-cp312-win_amd64.whl", hash = "sha256:8709a0f05d59a71f33fd05c17fc11fcb8c30140506e13c2f5e8ee1b8964e1b45", size = 453465, upload-time = "2025-10-28T20:57:00.795Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/78/7e90ca79e5aa39f9694dcfd74f4720782d3c6828113bb1f3197f7e7c4a56/aiohttp-3.13.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7519bdc7dfc1940d201651b52bf5e03f5503bda45ad6eacf64dda98be5b2b6be", size = 732139, upload-time = "2025-10-28T20:57:02.455Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ed/1f59215ab6853fbaa5c8495fa6cbc39edfc93553426152b75d82a5f32b76/aiohttp-3.13.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:088912a78b4d4f547a1f19c099d5a506df17eacec3c6f4375e2831ec1d995742", size = 490082, upload-time = "2025-10-28T20:57:04.784Z" },
-    { url = "https://files.pythonhosted.org/packages/68/7b/fe0fe0f5e05e13629d893c760465173a15ad0039c0a5b0d0040995c8075e/aiohttp-3.13.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5276807b9de9092af38ed23ce120539ab0ac955547b38563a9ba4f5b07b95293", size = 489035, upload-time = "2025-10-28T20:57:06.894Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/04/db5279e38471b7ac801d7d36a57d1230feeee130bbe2a74f72731b23c2b1/aiohttp-3.13.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1237c1375eaef0db4dcd7c2559f42e8af7b87ea7d295b118c60c36a6e61cb811", size = 1720387, upload-time = "2025-10-28T20:57:08.685Z" },
-    { url = "https://files.pythonhosted.org/packages/31/07/8ea4326bd7dae2bd59828f69d7fdc6e04523caa55e4a70f4a8725a7e4ed2/aiohttp-3.13.2-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:96581619c57419c3d7d78703d5b78c1e5e5fc0172d60f555bdebaced82ded19a", size = 1688314, upload-time = "2025-10-28T20:57:10.693Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ab/3d98007b5b87ffd519d065225438cc3b668b2f245572a8cb53da5dd2b1bc/aiohttp-3.13.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2713a95b47374169409d18103366de1050fe0ea73db358fc7a7acb2880422d4", size = 1756317, upload-time = "2025-10-28T20:57:12.563Z" },
-    { url = "https://files.pythonhosted.org/packages/97/3d/801ca172b3d857fafb7b50c7c03f91b72b867a13abca982ed6b3081774ef/aiohttp-3.13.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:228a1cd556b3caca590e9511a89444925da87d35219a49ab5da0c36d2d943a6a", size = 1858539, upload-time = "2025-10-28T20:57:14.623Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/0d/4764669bdf47bd472899b3d3db91fffbe925c8e3038ec591a2fd2ad6a14d/aiohttp-3.13.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ac6cde5fba8d7d8c6ac963dbb0256a9854e9fafff52fbcc58fdf819357892c3e", size = 1739597, upload-time = "2025-10-28T20:57:16.399Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/52/7bd3c6693da58ba16e657eb904a5b6decfc48ecd06e9ac098591653b1566/aiohttp-3.13.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f2bef8237544f4e42878c61cef4e2839fee6346dc60f5739f876a9c50be7fcdb", size = 1555006, upload-time = "2025-10-28T20:57:18.288Z" },
-    { url = "https://files.pythonhosted.org/packages/48/30/9586667acec5993b6f41d2ebcf96e97a1255a85f62f3c653110a5de4d346/aiohttp-3.13.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:16f15a4eac3bc2d76c45f7ebdd48a65d41b242eb6c31c2245463b40b34584ded", size = 1683220, upload-time = "2025-10-28T20:57:20.241Z" },
-    { url = "https://files.pythonhosted.org/packages/71/01/3afe4c96854cfd7b30d78333852e8e851dceaec1c40fd00fec90c6402dd2/aiohttp-3.13.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:bb7fb776645af5cc58ab804c58d7eba545a97e047254a52ce89c157b5af6cd0b", size = 1712570, upload-time = "2025-10-28T20:57:22.253Z" },
-    { url = "https://files.pythonhosted.org/packages/11/2c/22799d8e720f4697a9e66fd9c02479e40a49de3de2f0bbe7f9f78a987808/aiohttp-3.13.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:e1b4951125ec10c70802f2cb09736c895861cd39fd9dcb35107b4dc8ae6220b8", size = 1733407, upload-time = "2025-10-28T20:57:24.37Z" },
-    { url = "https://files.pythonhosted.org/packages/34/cb/90f15dd029f07cebbd91f8238a8b363978b530cd128488085b5703683594/aiohttp-3.13.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:550bf765101ae721ee1d37d8095f47b1f220650f85fe1af37a90ce75bab89d04", size = 1550093, upload-time = "2025-10-28T20:57:26.257Z" },
-    { url = "https://files.pythonhosted.org/packages/69/46/12dce9be9d3303ecbf4d30ad45a7683dc63d90733c2d9fe512be6716cd40/aiohttp-3.13.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fe91b87fc295973096251e2d25a811388e7d8adf3bd2b97ef6ae78bc4ac6c476", size = 1758084, upload-time = "2025-10-28T20:57:28.349Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c8/0932b558da0c302ffd639fc6362a313b98fdf235dc417bc2493da8394df7/aiohttp-3.13.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0c8e31cfcc4592cb200160344b2fb6ae0f9e4effe06c644b5a125d4ae5ebe23", size = 1716987, upload-time = "2025-10-28T20:57:30.233Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8b/f5bd1a75003daed099baec373aed678f2e9b34f2ad40d85baa1368556396/aiohttp-3.13.2-cp313-cp313-win32.whl", hash = "sha256:0740f31a60848d6edb296a0df827473eede90c689b8f9f2a4cdde74889eb2254", size = 425859, upload-time = "2025-10-28T20:57:32.105Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/28/a8a9fc6957b2cee8902414e41816b5ab5536ecf43c3b1843c10e82c559b2/aiohttp-3.13.2-cp313-cp313-win_amd64.whl", hash = "sha256:a88d13e7ca367394908f8a276b89d04a3652044612b9a408a0bb22a5ed976a1a", size = 452192, upload-time = "2025-10-28T20:57:34.166Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/36/e2abae1bd815f01c957cbf7be817b3043304e1c87bad526292a0410fdcf9/aiohttp-3.13.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2475391c29230e063ef53a66669b7b691c9bfc3f1426a0f7bcdf1216bdbac38b", size = 735234, upload-time = "2025-10-28T20:57:36.415Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/e3/1ee62dde9b335e4ed41db6bba02613295a0d5b41f74a783c142745a12763/aiohttp-3.13.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f33c8748abef4d8717bb20e8fb1b3e07c6adacb7fd6beaae971a764cf5f30d61", size = 490733, upload-time = "2025-10-28T20:57:38.205Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/aa/7a451b1d6a04e8d15a362af3e9b897de71d86feac3babf8894545d08d537/aiohttp-3.13.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ae32f24bbfb7dbb485a24b30b1149e2f200be94777232aeadba3eecece4d0aa4", size = 491303, upload-time = "2025-10-28T20:57:40.122Z" },
-    { url = "https://files.pythonhosted.org/packages/57/1e/209958dbb9b01174870f6a7538cd1f3f28274fdbc88a750c238e2c456295/aiohttp-3.13.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d7f02042c1f009ffb70067326ef183a047425bb2ff3bc434ead4dd4a4a66a2b", size = 1717965, upload-time = "2025-10-28T20:57:42.28Z" },
-    { url = "https://files.pythonhosted.org/packages/08/aa/6a01848d6432f241416bc4866cae8dc03f05a5a884d2311280f6a09c73d6/aiohttp-3.13.2-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93655083005d71cd6c072cdab54c886e6570ad2c4592139c3fb967bfc19e4694", size = 1667221, upload-time = "2025-10-28T20:57:44.869Z" },
-    { url = "https://files.pythonhosted.org/packages/87/4f/36c1992432d31bbc789fa0b93c768d2e9047ec8c7177e5cd84ea85155f36/aiohttp-3.13.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0db1e24b852f5f664cd728db140cf11ea0e82450471232a394b3d1a540b0f906", size = 1757178, upload-time = "2025-10-28T20:57:47.216Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/b4/8e940dfb03b7e0f68a82b88fd182b9be0a65cb3f35612fe38c038c3112cf/aiohttp-3.13.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b009194665bcd128e23eaddef362e745601afa4641930848af4c8559e88f18f9", size = 1838001, upload-time = "2025-10-28T20:57:49.337Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ef/39f3448795499c440ab66084a9db7d20ca7662e94305f175a80f5b7e0072/aiohttp-3.13.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c038a8fdc8103cd51dbd986ecdce141473ffd9775a7a8057a6ed9c3653478011", size = 1716325, upload-time = "2025-10-28T20:57:51.327Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/51/b311500ffc860b181c05d91c59a1313bdd05c82960fdd4035a15740d431e/aiohttp-3.13.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66bac29b95a00db411cd758fea0e4b9bdba6d549dfe333f9a945430f5f2cc5a6", size = 1547978, upload-time = "2025-10-28T20:57:53.554Z" },
-    { url = "https://files.pythonhosted.org/packages/31/64/b9d733296ef79815226dab8c586ff9e3df41c6aff2e16c06697b2d2e6775/aiohttp-3.13.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4ebf9cfc9ba24a74cf0718f04aac2a3bbe745902cc7c5ebc55c0f3b5777ef213", size = 1682042, upload-time = "2025-10-28T20:57:55.617Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/30/43d3e0f9d6473a6db7d472104c4eff4417b1e9df01774cb930338806d36b/aiohttp-3.13.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a4b88ebe35ce54205c7074f7302bd08a4cb83256a3e0870c72d6f68a3aaf8e49", size = 1680085, upload-time = "2025-10-28T20:57:57.59Z" },
-    { url = "https://files.pythonhosted.org/packages/16/51/c709f352c911b1864cfd1087577760ced64b3e5bee2aa88b8c0c8e2e4972/aiohttp-3.13.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:98c4fb90bb82b70a4ed79ca35f656f4281885be076f3f970ce315402b53099ae", size = 1728238, upload-time = "2025-10-28T20:57:59.525Z" },
-    { url = "https://files.pythonhosted.org/packages/19/e2/19bd4c547092b773caeb48ff5ae4b1ae86756a0ee76c16727fcfd281404b/aiohttp-3.13.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:ec7534e63ae0f3759df3a1ed4fa6bc8f75082a924b590619c0dd2f76d7043caa", size = 1544395, upload-time = "2025-10-28T20:58:01.914Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/87/860f2803b27dfc5ed7be532832a3498e4919da61299b4a1f8eb89b8ff44d/aiohttp-3.13.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5b927cf9b935a13e33644cbed6c8c4b2d0f25b713d838743f8fe7191b33829c4", size = 1742965, upload-time = "2025-10-28T20:58:03.972Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7f/db2fc7618925e8c7a601094d5cbe539f732df4fb570740be88ed9e40e99a/aiohttp-3.13.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:88d6c017966a78c5265d996c19cdb79235be5e6412268d7e2ce7dee339471b7a", size = 1697585, upload-time = "2025-10-28T20:58:06.189Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/07/9127916cb09bb38284db5036036042b7b2c514c8ebaeee79da550c43a6d6/aiohttp-3.13.2-cp314-cp314-win32.whl", hash = "sha256:f7c183e786e299b5d6c49fb43a769f8eb8e04a2726a2bd5887b98b5cc2d67940", size = 431621, upload-time = "2025-10-28T20:58:08.636Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/41/554a8a380df6d3a2bba8a7726429a23f4ac62aaf38de43bb6d6cde7b4d4d/aiohttp-3.13.2-cp314-cp314-win_amd64.whl", hash = "sha256:fe242cd381e0fb65758faf5ad96c2e460df6ee5b2de1072fe97e4127927e00b4", size = 457627, upload-time = "2025-10-28T20:58:11Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/8e/3824ef98c039d3951cb65b9205a96dd2b20f22241ee17d89c5701557c826/aiohttp-3.13.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:f10d9c0b0188fe85398c61147bbd2a657d616c876863bfeff43376e0e3134673", size = 767360, upload-time = "2025-10-28T20:58:13.358Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/0f/6a03e3fc7595421274fa34122c973bde2d89344f8a881b728fa8c774e4f1/aiohttp-3.13.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:e7c952aefdf2460f4ae55c5e9c3e80aa72f706a6317e06020f80e96253b1accd", size = 504616, upload-time = "2025-10-28T20:58:15.339Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/aa/ed341b670f1bc8a6f2c6a718353d13b9546e2cef3544f573c6a1ff0da711/aiohttp-3.13.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c20423ce14771d98353d2e25e83591fa75dfa90a3c1848f3d7c68243b4fbded3", size = 509131, upload-time = "2025-10-28T20:58:17.693Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/f0/c68dac234189dae5c4bbccc0f96ce0cc16b76632cfc3a08fff180045cfa4/aiohttp-3.13.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e96eb1a34396e9430c19d8338d2ec33015e4a87ef2b4449db94c22412e25ccdf", size = 1864168, upload-time = "2025-10-28T20:58:20.113Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/65/75a9a76db8364b5d0e52a0c20eabc5d52297385d9af9c35335b924fafdee/aiohttp-3.13.2-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23fb0783bc1a33640036465019d3bba069942616a6a2353c6907d7fe1ccdaf4e", size = 1719200, upload-time = "2025-10-28T20:58:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/55/8df2ed78d7f41d232f6bd3ff866b6f617026551aa1d07e2f03458f964575/aiohttp-3.13.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e1a9bea6244a1d05a4e57c295d69e159a5c50d8ef16aa390948ee873478d9a5", size = 1843497, upload-time = "2025-10-28T20:58:24.672Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/e0/94d7215e405c5a02ccb6a35c7a3a6cfff242f457a00196496935f700cde5/aiohttp-3.13.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0a3d54e822688b56e9f6b5816fb3de3a3a64660efac64e4c2dc435230ad23bad", size = 1935703, upload-time = "2025-10-28T20:58:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/78/1eeb63c3f9b2d1015a4c02788fb543141aad0a03ae3f7a7b669b2483f8d4/aiohttp-3.13.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a653d872afe9f33497215745da7a943d1dc15b728a9c8da1c3ac423af35178e", size = 1792738, upload-time = "2025-10-28T20:58:29.787Z" },
-    { url = "https://files.pythonhosted.org/packages/41/75/aaf1eea4c188e51538c04cc568040e3082db263a57086ea74a7d38c39e42/aiohttp-3.13.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:56d36e80d2003fa3fc0207fac644216d8532e9504a785ef9a8fd013f84a42c61", size = 1624061, upload-time = "2025-10-28T20:58:32.529Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/c2/3b6034de81fbcc43de8aeb209073a2286dfb50b86e927b4efd81cf848197/aiohttp-3.13.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:78cd586d8331fb8e241c2dd6b2f4061778cc69e150514b39a9e28dd050475661", size = 1789201, upload-time = "2025-10-28T20:58:34.618Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/38/c15dcf6d4d890217dae79d7213988f4e5fe6183d43893a9cf2fe9e84ca8d/aiohttp-3.13.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:20b10bbfbff766294fe99987f7bb3b74fdd2f1a2905f2562132641ad434dcf98", size = 1776868, upload-time = "2025-10-28T20:58:38.835Z" },
-    { url = "https://files.pythonhosted.org/packages/04/75/f74fd178ac81adf4f283a74847807ade5150e48feda6aef024403716c30c/aiohttp-3.13.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:9ec49dff7e2b3c85cdeaa412e9d438f0ecd71676fde61ec57027dd392f00c693", size = 1790660, upload-time = "2025-10-28T20:58:41.507Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/80/7368bd0d06b16b3aba358c16b919e9c46cf11587dc572091031b0e9e3ef0/aiohttp-3.13.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:94f05348c4406450f9d73d38efb41d669ad6cd90c7ee194810d0eefbfa875a7a", size = 1617548, upload-time = "2025-10-28T20:58:43.674Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/4b/a6212790c50483cb3212e507378fbe26b5086d73941e1ec4b56a30439688/aiohttp-3.13.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:fa4dcb605c6f82a80c7f95713c2b11c3b8e9893b3ebd2bc9bde93165ed6107be", size = 1817240, upload-time = "2025-10-28T20:58:45.787Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/f7/ba5f0ba4ea8d8f3c32850912944532b933acbf0f3a75546b89269b9b7dde/aiohttp-3.13.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cf00e5db968c3f67eccd2778574cf64d8b27d95b237770aa32400bd7a1ca4f6c", size = 1762334, upload-time = "2025-10-28T20:58:47.936Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/83/1a5a1856574588b1cad63609ea9ad75b32a8353ac995d830bf5da9357364/aiohttp-3.13.2-cp314-cp314t-win32.whl", hash = "sha256:d23b5fe492b0805a50d3371e8a728a9134d8de5447dce4c885f5587294750734", size = 464685, upload-time = "2025-10-28T20:58:50.642Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/4d/d22668674122c08f4d56972297c51a624e64b3ed1efaa40187607a7cb66e/aiohttp-3.13.2-cp314-cp314t-win_amd64.whl", hash = "sha256:ff0a7b0a82a7ab905cbda74006318d1b12e37c797eb1b0d4eb3e316cf47f658f", size = 498093, upload-time = "2025-10-28T20:58:52.782Z" },
-]
-
-[[package]]
-name = "aiosignal"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
-]
-
-[[package]]
 name = "altair"
 version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -410,142 +303,12 @@ wheels = [
 ]
 
 [[package]]
-name = "fastuuid"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
-    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
-    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
-    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
-    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
-    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
-    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
-    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
-    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
-    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
-    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
-    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
-]
-
-[[package]]
-name = "frozenlist"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
-    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
-    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
-    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
-    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ba/b0b3de23f40bc55a7057bd38434e25c34fa48e17f20ee273bbde5e0650f3/frozenlist-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96153e77a591c8adc2ee805756c61f59fef4cf4073a9275ee86fe8cba41241f7", size = 49651, upload-time = "2025-10-06T05:36:28.855Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ab/6e5080ee374f875296c4243c381bbdef97a9ac39c6e3ce1d5f7d42cb78d6/frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40", size = 49417, upload-time = "2025-10-06T05:36:29.877Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027", size = 234391, upload-time = "2025-10-06T05:36:31.301Z" },
-    { url = "https://files.pythonhosted.org/packages/40/76/c202df58e3acdf12969a7895fd6f3bc016c642e6726aa63bd3025e0fc71c/frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822", size = 233048, upload-time = "2025-10-06T05:36:32.531Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c0/8746afb90f17b73ca5979c7a3958116e105ff796e718575175319b5bb4ce/frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121", size = 226549, upload-time = "2025-10-06T05:36:33.706Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/eb/4c7eefc718ff72f9b6c4893291abaae5fbc0c82226a32dcd8ef4f7a5dbef/frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5", size = 239833, upload-time = "2025-10-06T05:36:34.947Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/4e/e5c02187cf704224f8b21bee886f3d713ca379535f16893233b9d672ea71/frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e", size = 245363, upload-time = "2025-10-06T05:36:36.534Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/96/cb85ec608464472e82ad37a17f844889c36100eed57bea094518bf270692/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11", size = 229314, upload-time = "2025-10-06T05:36:38.582Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/6f/4ae69c550e4cee66b57887daeebe006fe985917c01d0fff9caab9883f6d0/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1", size = 243365, upload-time = "2025-10-06T05:36:40.152Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/58/afd56de246cf11780a40a2c28dc7cbabbf06337cc8ddb1c780a2d97e88d8/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1", size = 237763, upload-time = "2025-10-06T05:36:41.355Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/36/cdfaf6ed42e2644740d4a10452d8e97fa1c062e2a8006e4b09f1b5fd7d63/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8", size = 240110, upload-time = "2025-10-06T05:36:42.716Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a8/9ea226fbefad669f11b52e864c55f0bd57d3c8d7eb07e9f2e9a0b39502e1/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed", size = 233717, upload-time = "2025-10-06T05:36:44.251Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/0b/1b5531611e83ba7d13ccc9988967ea1b51186af64c42b7a7af465dcc9568/frozenlist-1.8.0-cp313-cp313-win32.whl", hash = "sha256:8b7b94a067d1c504ee0b16def57ad5738701e4ba10cec90529f13fa03c833496", size = 39628, upload-time = "2025-10-06T05:36:45.423Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/cf/174c91dbc9cc49bc7b7aab74d8b734e974d1faa8f191c74af9b7e80848e6/frozenlist-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:878be833caa6a3821caf85eb39c5ba92d28e85df26d57afb06b35b2efd937231", size = 43882, upload-time = "2025-10-06T05:36:46.796Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/17/502cd212cbfa96eb1388614fe39a3fc9ab87dbbe042b66f97acb57474834/frozenlist-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:44389d135b3ff43ba8cc89ff7f51f5a0bb6b63d829c8300f79a2fe4fe61bcc62", size = 39676, upload-time = "2025-10-06T05:36:47.8Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/5c/3bbfaa920dfab09e76946a5d2833a7cbdf7b9b4a91c714666ac4855b88b4/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94", size = 89235, upload-time = "2025-10-06T05:36:48.78Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/d6/f03961ef72166cec1687e84e8925838442b615bd0b8854b54923ce5b7b8a/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07cdca25a91a4386d2e76ad992916a85038a9b97561bf7a3fd12d5d9ce31870c", size = 50742, upload-time = "2025-10-06T05:36:49.837Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/bb/a6d12b7ba4c3337667d0e421f7181c82dda448ce4e7ad7ecd249a16fa806/frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52", size = 51725, upload-time = "2025-10-06T05:36:50.851Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/71/d1fed0ffe2c2ccd70b43714c6cab0f4188f09f8a67a7914a6b46ee30f274/frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51", size = 284533, upload-time = "2025-10-06T05:36:51.898Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/fb1685a7b009d89f9bf78a42d94461bc06581f6e718c39344754a5d9bada/frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65", size = 292506, upload-time = "2025-10-06T05:36:53.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/3b/b991fe1612703f7e0d05c0cf734c1b77aaf7c7d321df4572e8d36e7048c8/frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82", size = 274161, upload-time = "2025-10-06T05:36:54.309Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ec/c5c618767bcdf66e88945ec0157d7f6c4a1322f1473392319b7a2501ded7/frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714", size = 294676, upload-time = "2025-10-06T05:36:55.566Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ce/3934758637d8f8a88d11f0585d6495ef54b2044ed6ec84492a91fa3b27aa/frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d", size = 300638, upload-time = "2025-10-06T05:36:56.758Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/4f/a7e4d0d467298f42de4b41cbc7ddaf19d3cfeabaf9ff97c20c6c7ee409f9/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506", size = 283067, upload-time = "2025-10-06T05:36:57.965Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/48/c7b163063d55a83772b268e6d1affb960771b0e203b632cfe09522d67ea5/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51", size = 292101, upload-time = "2025-10-06T05:36:59.237Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/d0/2366d3c4ecdc2fd391e0afa6e11500bfba0ea772764d631bbf82f0136c9d/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e", size = 289901, upload-time = "2025-10-06T05:37:00.811Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/94/daff920e82c1b70e3618a2ac39fbc01ae3e2ff6124e80739ce5d71c9b920/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0", size = 289395, upload-time = "2025-10-06T05:37:02.115Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/20/bba307ab4235a09fdcd3cc5508dbabd17c4634a1af4b96e0f69bfe551ebd/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41", size = 283659, upload-time = "2025-10-06T05:37:03.711Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/00/04ca1c3a7a124b6de4f8a9a17cc2fcad138b4608e7a3fc5877804b8715d7/frozenlist-1.8.0-cp313-cp313t-win32.whl", hash = "sha256:0f96534f8bfebc1a394209427d0f8a63d343c9779cda6fc25e8e121b5fd8555b", size = 43492, upload-time = "2025-10-06T05:37:04.915Z" },
-    { url = "https://files.pythonhosted.org/packages/59/5e/c69f733a86a94ab10f68e496dc6b7e8bc078ebb415281d5698313e3af3a1/frozenlist-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5d63a068f978fc69421fb0e6eb91a9603187527c86b7cd3f534a5b77a592b888", size = 48034, upload-time = "2025-10-06T05:37:06.343Z" },
-    { url = "https://files.pythonhosted.org/packages/16/6c/be9d79775d8abe79b05fa6d23da99ad6e7763a1d080fbae7290b286093fd/frozenlist-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf0a7e10b077bf5fb9380ad3ae8ce20ef919a6ad93b4552896419ac7e1d8e042", size = 41749, upload-time = "2025-10-06T05:37:07.431Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
-    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
-    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
-    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
-    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
-    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
-    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
-    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
-    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
-    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
-    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
 ]
 
 [[package]]
@@ -678,15 +441,6 @@ wheels = [
 ]
 
 [[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -716,19 +470,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
 name = "httplib2"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -741,39 +482,22 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
 name = "huggingface-hub"
-version = "1.1.5"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "shellingham" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer-slim" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/02/c3d534d7498ba2792da1d2ce56b5d38bbcbcbbba62071c90ee289b408e8d/huggingface_hub-1.1.5.tar.gz", hash = "sha256:40ba5c9a08792d888fde6088920a0a71ab3cd9d5e6617c81a797c657f1fd9968", size = 607199, upload-time = "2025-11-20T15:49:32.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/f4/124858007ddf3c61e9b144107304c9152fa80b5b6c168da07d86fe583cc1/huggingface_hub-1.1.5-py3-none-any.whl", hash = "sha256:e88ecc129011f37b868586bbcfae6c56868cae80cd56a79d61575426a3aa0d7d", size = 516000, upload-time = "2025-11-20T15:49:30.926Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
 ]
 
 [[package]]
@@ -792,18 +516,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/63/0eea51c9c263c18021cdc5866def55c98393f3bd74bbb8e3053e36f0f81a/IMAPClient-3.0.1.zip", hash = "sha256:78e6d62fbfbbe233e1f0e0e993160fd665eb1fd35973acddc61c15719b22bc02", size = 244222, upload-time = "2023-12-02T08:24:15.344Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/8a/d1364c1c6d8f53ea390e8f1c6da220a4f9ee478ac8a473ae0669a2fb6f51/IMAPClient-3.0.1-py2.py3-none-any.whl", hash = "sha256:d77d77caa4123e0233b5cf2b9c54a078522e63270b88d3f48653a28637fd8828", size = 182490, upload-time = "2023-12-02T08:24:11.854Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
 ]
 
 [[package]]
@@ -828,71 +540,12 @@ wheels = [
 ]
 
 [[package]]
-name = "jiter"
-version = "0.12.0"
+name = "joblib"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/9d/e0660989c1370e25848bb4c52d061c71837239738ad937e83edca174c273/jiter-0.12.0.tar.gz", hash = "sha256:64dfcd7d5c168b38d3f9f8bba7fc639edb3418abcc74f22fdbe6b8938293f30b", size = 168294, upload-time = "2025-11-09T20:49:23.302Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/c9/5b9f7b4983f1b542c64e84165075335e8a236fa9e2ea03a0c79780062be8/jiter-0.12.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:305e061fa82f4680607a775b2e8e0bcb071cd2205ac38e6ef48c8dd5ebe1cf37", size = 314449, upload-time = "2025-11-09T20:47:22.999Z" },
-    { url = "https://files.pythonhosted.org/packages/98/6e/e8efa0e78de00db0aee82c0cf9e8b3f2027efd7f8a71f859d8f4be8e98ef/jiter-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5c1860627048e302a528333c9307c818c547f214d8659b0705d2195e1a94b274", size = 319855, upload-time = "2025-11-09T20:47:24.779Z" },
-    { url = "https://files.pythonhosted.org/packages/20/26/894cd88e60b5d58af53bec5c6759d1292bd0b37a8b5f60f07abf7a63ae5f/jiter-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df37577a4f8408f7e0ec3205d2a8f87672af8f17008358063a4d6425b6081ce3", size = 350171, upload-time = "2025-11-09T20:47:26.469Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/27/a7b818b9979ac31b3763d25f3653ec3a954044d5e9f5d87f2f247d679fd1/jiter-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75fdd787356c1c13a4f40b43c2156276ef7a71eb487d98472476476d803fb2cf", size = 365590, upload-time = "2025-11-09T20:47:27.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/7e/e46195801a97673a83746170b17984aa8ac4a455746354516d02ca5541b4/jiter-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1eb5db8d9c65b112aacf14fcd0faae9913d07a8afea5ed06ccdd12b724e966a1", size = 479462, upload-time = "2025-11-09T20:47:29.654Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/75/f833bfb009ab4bd11b1c9406d333e3b4357709ed0570bb48c7c06d78c7dd/jiter-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:73c568cc27c473f82480abc15d1301adf333a7ea4f2e813d6a2c7d8b6ba8d0df", size = 378983, upload-time = "2025-11-09T20:47:31.026Z" },
-    { url = "https://files.pythonhosted.org/packages/71/b3/7a69d77943cc837d30165643db753471aff5df39692d598da880a6e51c24/jiter-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4321e8a3d868919bcb1abb1db550d41f2b5b326f72df29e53b2df8b006eb9403", size = 361328, upload-time = "2025-11-09T20:47:33.286Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ac/a78f90caf48d65ba70d8c6efc6f23150bc39dc3389d65bbec2a95c7bc628/jiter-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a51bad79f8cc9cac2b4b705039f814049142e0050f30d91695a2d9a6611f126", size = 386740, upload-time = "2025-11-09T20:47:34.703Z" },
-    { url = "https://files.pythonhosted.org/packages/39/b6/5d31c2cc8e1b6a6bcf3c5721e4ca0a3633d1ab4754b09bc7084f6c4f5327/jiter-0.12.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2a67b678f6a5f1dd6c36d642d7db83e456bc8b104788262aaefc11a22339f5a9", size = 520875, upload-time = "2025-11-09T20:47:36.058Z" },
-    { url = "https://files.pythonhosted.org/packages/30/b5/4df540fae4e9f68c54b8dab004bd8c943a752f0b00efd6e7d64aa3850339/jiter-0.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efe1a211fe1fd14762adea941e3cfd6c611a136e28da6c39272dbb7a1bbe6a86", size = 511457, upload-time = "2025-11-09T20:47:37.932Z" },
-    { url = "https://files.pythonhosted.org/packages/07/65/86b74010e450a1a77b2c1aabb91d4a91dd3cd5afce99f34d75fd1ac64b19/jiter-0.12.0-cp312-cp312-win32.whl", hash = "sha256:d779d97c834b4278276ec703dc3fc1735fca50af63eb7262f05bdb4e62203d44", size = 204546, upload-time = "2025-11-09T20:47:40.47Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c7/6659f537f9562d963488e3e55573498a442503ced01f7e169e96a6110383/jiter-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e8269062060212b373316fe69236096aaf4c49022d267c6736eebd66bbbc60bb", size = 205196, upload-time = "2025-11-09T20:47:41.794Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f4/935304f5169edadfec7f9c01eacbce4c90bb9a82035ac1de1f3bd2d40be6/jiter-0.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:06cb970936c65de926d648af0ed3d21857f026b1cf5525cb2947aa5e01e05789", size = 186100, upload-time = "2025-11-09T20:47:43.007Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a6/97209693b177716e22576ee1161674d1d58029eb178e01866a0422b69224/jiter-0.12.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6cc49d5130a14b732e0612bc76ae8db3b49898732223ef8b7599aa8d9810683e", size = 313658, upload-time = "2025-11-09T20:47:44.424Z" },
-    { url = "https://files.pythonhosted.org/packages/06/4d/125c5c1537c7d8ee73ad3d530a442d6c619714b95027143f1b61c0b4dfe0/jiter-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37f27a32ce36364d2fa4f7fdc507279db604d27d239ea2e044c8f148410defe1", size = 318605, upload-time = "2025-11-09T20:47:45.973Z" },
-    { url = "https://files.pythonhosted.org/packages/99/bf/a840b89847885064c41a5f52de6e312e91fa84a520848ee56c97e4fa0205/jiter-0.12.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbc0944aa3d4b4773e348cda635252824a78f4ba44328e042ef1ff3f6080d1cf", size = 349803, upload-time = "2025-11-09T20:47:47.535Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/88/e63441c28e0db50e305ae23e19c1d8fae012d78ed55365da392c1f34b09c/jiter-0.12.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da25c62d4ee1ffbacb97fac6dfe4dcd6759ebdc9015991e92a6eae5816287f44", size = 365120, upload-time = "2025-11-09T20:47:49.284Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7c/49b02714af4343970eb8aca63396bc1c82fa01197dbb1e9b0d274b550d4e/jiter-0.12.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:048485c654b838140b007390b8182ba9774621103bd4d77c9c3f6f117474ba45", size = 479918, upload-time = "2025-11-09T20:47:50.807Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ba/0a809817fdd5a1db80490b9150645f3aae16afad166960bcd562be194f3b/jiter-0.12.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:635e737fbb7315bef0037c19b88b799143d2d7d3507e61a76751025226b3ac87", size = 379008, upload-time = "2025-11-09T20:47:52.211Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/c3/c9fc0232e736c8877d9e6d83d6eeb0ba4e90c6c073835cc2e8f73fdeef51/jiter-0.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e017c417b1ebda911bd13b1e40612704b1f5420e30695112efdbed8a4b389ed", size = 361785, upload-time = "2025-11-09T20:47:53.512Z" },
-    { url = "https://files.pythonhosted.org/packages/96/61/61f69b7e442e97ca6cd53086ddc1cf59fb830549bc72c0a293713a60c525/jiter-0.12.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:89b0bfb8b2bf2351fba36bb211ef8bfceba73ef58e7f0c68fb67b5a2795ca2f9", size = 386108, upload-time = "2025-11-09T20:47:54.893Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/2e/76bb3332f28550c8f1eba3bf6e5efe211efda0ddbbaf24976bc7078d42a5/jiter-0.12.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:f5aa5427a629a824a543672778c9ce0c5e556550d1569bb6ea28a85015287626", size = 519937, upload-time = "2025-11-09T20:47:56.253Z" },
-    { url = "https://files.pythonhosted.org/packages/84/d6/fa96efa87dc8bff2094fb947f51f66368fa56d8d4fc9e77b25d7fbb23375/jiter-0.12.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed53b3d6acbcb0fd0b90f20c7cb3b24c357fe82a3518934d4edfa8c6898e498c", size = 510853, upload-time = "2025-11-09T20:47:58.32Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/28/93f67fdb4d5904a708119a6ab58a8f1ec226ff10a94a282e0215402a8462/jiter-0.12.0-cp313-cp313-win32.whl", hash = "sha256:4747de73d6b8c78f2e253a2787930f4fffc68da7fa319739f57437f95963c4de", size = 204699, upload-time = "2025-11-09T20:47:59.686Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/1f/30b0eb087045a0abe2a5c9c0c0c8da110875a1d3be83afd4a9a4e548be3c/jiter-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:e25012eb0c456fcc13354255d0338cd5397cce26c77b2832b3c4e2e255ea5d9a", size = 204258, upload-time = "2025-11-09T20:48:01.01Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/f4/2b4daf99b96bce6fc47971890b14b2a36aef88d7beb9f057fafa032c6141/jiter-0.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:c97b92c54fe6110138c872add030a1f99aea2401ddcdaa21edf74705a646dd60", size = 185503, upload-time = "2025-11-09T20:48:02.35Z" },
-    { url = "https://files.pythonhosted.org/packages/39/ca/67bb15a7061d6fe20b9b2a2fd783e296a1e0f93468252c093481a2f00efa/jiter-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:53839b35a38f56b8be26a7851a48b89bc47e5d88e900929df10ed93b95fea3d6", size = 317965, upload-time = "2025-11-09T20:48:03.783Z" },
-    { url = "https://files.pythonhosted.org/packages/18/af/1788031cd22e29c3b14bc6ca80b16a39a0b10e611367ffd480c06a259831/jiter-0.12.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94f669548e55c91ab47fef8bddd9c954dab1938644e715ea49d7e117015110a4", size = 345831, upload-time = "2025-11-09T20:48:05.55Z" },
-    { url = "https://files.pythonhosted.org/packages/05/17/710bf8472d1dff0d3caf4ced6031060091c1320f84ee7d5dcbed1f352417/jiter-0.12.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:351d54f2b09a41600ffea43d081522d792e81dcfb915f6d2d242744c1cc48beb", size = 361272, upload-time = "2025-11-09T20:48:06.951Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f1/1dcc4618b59761fef92d10bcbb0b038b5160be653b003651566a185f1a5c/jiter-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2a5e90604620f94bf62264e7c2c038704d38217b7465b863896c6d7c902b06c7", size = 204604, upload-time = "2025-11-09T20:48:08.328Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/32/63cb1d9f1c5c6632a783c0052cde9ef7ba82688f7065e2f0d5f10a7e3edb/jiter-0.12.0-cp313-cp313t-win_arm64.whl", hash = "sha256:88ef757017e78d2860f96250f9393b7b577b06a956ad102c29c8237554380db3", size = 185628, upload-time = "2025-11-09T20:48:09.572Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/99/45c9f0dbe4a1416b2b9a8a6d1236459540f43d7fb8883cff769a8db0612d/jiter-0.12.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c46d927acd09c67a9fb1416df45c5a04c27e83aae969267e98fba35b74e99525", size = 312478, upload-time = "2025-11-09T20:48:10.898Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/a7/54ae75613ba9e0f55fcb0bc5d1f807823b5167cc944e9333ff322e9f07dd/jiter-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:774ff60b27a84a85b27b88cd5583899c59940bcc126caca97eb2a9df6aa00c49", size = 318706, upload-time = "2025-11-09T20:48:12.266Z" },
-    { url = "https://files.pythonhosted.org/packages/59/31/2aa241ad2c10774baf6c37f8b8e1f39c07db358f1329f4eb40eba179c2a2/jiter-0.12.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5433fab222fb072237df3f637d01b81f040a07dcac1cb4a5c75c7aa9ed0bef1", size = 351894, upload-time = "2025-11-09T20:48:13.673Z" },
-    { url = "https://files.pythonhosted.org/packages/54/4f/0f2759522719133a9042781b18cc94e335b6d290f5e2d3e6899d6af933e3/jiter-0.12.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8c593c6e71c07866ec6bfb790e202a833eeec885022296aff6b9e0b92d6a70e", size = 365714, upload-time = "2025-11-09T20:48:15.083Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/6f/806b895f476582c62a2f52c453151edd8a0fde5411b0497baaa41018e878/jiter-0.12.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:90d32894d4c6877a87ae00c6b915b609406819dce8bc0d4e962e4de2784e567e", size = 478989, upload-time = "2025-11-09T20:48:16.706Z" },
-    { url = "https://files.pythonhosted.org/packages/86/6c/012d894dc6e1033acd8db2b8346add33e413ec1c7c002598915278a37f79/jiter-0.12.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:798e46eed9eb10c3adbbacbd3bdb5ecd4cf7064e453d00dbef08802dae6937ff", size = 378615, upload-time = "2025-11-09T20:48:18.614Z" },
-    { url = "https://files.pythonhosted.org/packages/87/30/d718d599f6700163e28e2c71c0bbaf6dace692e7df2592fd793ac9276717/jiter-0.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3f1368f0a6719ea80013a4eb90ba72e75d7ea67cfc7846db2ca504f3df0169a", size = 364745, upload-time = "2025-11-09T20:48:20.117Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/85/315b45ce4b6ddc7d7fceca24068543b02bdc8782942f4ee49d652e2cc89f/jiter-0.12.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:65f04a9d0b4406f7e51279710b27484af411896246200e461d80d3ba0caa901a", size = 386502, upload-time = "2025-11-09T20:48:21.543Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0b/ce0434fb40c5b24b368fe81b17074d2840748b4952256bab451b72290a49/jiter-0.12.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:fd990541982a24281d12b67a335e44f117e4c6cbad3c3b75c7dea68bf4ce3a67", size = 519845, upload-time = "2025-11-09T20:48:22.964Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/a3/7a7a4488ba052767846b9c916d208b3ed114e3eb670ee984e4c565b9cf0d/jiter-0.12.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b111b0e9152fa7df870ecaebb0bd30240d9f7fff1f2003bcb4ed0f519941820b", size = 510701, upload-time = "2025-11-09T20:48:24.483Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/16/052ffbf9d0467b70af24e30f91e0579e13ded0c17bb4a8eb2aed3cb60131/jiter-0.12.0-cp314-cp314-win32.whl", hash = "sha256:a78befb9cc0a45b5a5a0d537b06f8544c2ebb60d19d02c41ff15da28a9e22d42", size = 205029, upload-time = "2025-11-09T20:48:25.749Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/18/3cf1f3f0ccc789f76b9a754bdb7a6977e5d1d671ee97a9e14f7eb728d80e/jiter-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:e1fe01c082f6aafbe5c8faf0ff074f38dfb911d53f07ec333ca03f8f6226debf", size = 204960, upload-time = "2025-11-09T20:48:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/02/68/736821e52ecfdeeb0f024b8ab01b5a229f6b9293bbdb444c27efade50b0f/jiter-0.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:d72f3b5a432a4c546ea4bedc84cce0c3404874f1d1676260b9c7f048a9855451", size = 185529, upload-time = "2025-11-09T20:48:29.125Z" },
-    { url = "https://files.pythonhosted.org/packages/30/61/12ed8ee7a643cce29ac97c2281f9ce3956eb76b037e88d290f4ed0d41480/jiter-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e6ded41aeba3603f9728ed2b6196e4df875348ab97b28fc8afff115ed42ba7a7", size = 318974, upload-time = "2025-11-09T20:48:30.87Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c6/f3041ede6d0ed5e0e79ff0de4c8f14f401bbf196f2ef3971cdbe5fd08d1d/jiter-0.12.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a947920902420a6ada6ad51892082521978e9dd44a802663b001436e4b771684", size = 345932, upload-time = "2025-11-09T20:48:32.658Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5d/4d94835889edd01ad0e2dbfc05f7bdfaed46292e7b504a6ac7839aa00edb/jiter-0.12.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:add5e227e0554d3a52cf390a7635edaffdf4f8fce4fdbcef3cc2055bb396a30c", size = 367243, upload-time = "2025-11-09T20:48:34.093Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/76/0051b0ac2816253a99d27baf3dda198663aff882fa6ea7deeb94046da24e/jiter-0.12.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f9b1cda8fcb736250d7e8711d4580ebf004a46771432be0ae4796944b5dfa5d", size = 479315, upload-time = "2025-11-09T20:48:35.507Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ae/83f793acd68e5cb24e483f44f482a1a15601848b9b6f199dacb970098f77/jiter-0.12.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:deeb12a2223fe0135c7ff1356a143d57f95bbf1f4a66584f1fc74df21d86b993", size = 380714, upload-time = "2025-11-09T20:48:40.014Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/4808a88338ad2c228b1126b93fcd8ba145e919e886fe910d578230dabe3b/jiter-0.12.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c596cc0f4cb574877550ce4ecd51f8037469146addd676d7c1a30ebe6391923f", size = 365168, upload-time = "2025-11-09T20:48:41.462Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/d4/04619a9e8095b42aef436b5aeb4c0282b4ff1b27d1db1508df9f5dc82750/jiter-0.12.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ab4c823b216a4aeab3fdbf579c5843165756bd9ad87cc6b1c65919c4715f783", size = 387893, upload-time = "2025-11-09T20:48:42.921Z" },
-    { url = "https://files.pythonhosted.org/packages/17/ea/d3c7e62e4546fdc39197fa4a4315a563a89b95b6d54c0d25373842a59cbe/jiter-0.12.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e427eee51149edf962203ff8db75a7514ab89be5cb623fb9cea1f20b54f1107b", size = 520828, upload-time = "2025-11-09T20:48:44.278Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/0b/c6d3562a03fd767e31cb119d9041ea7958c3c80cb3d753eafb19b3b18349/jiter-0.12.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:edb868841f84c111255ba5e80339d386d937ec1fdce419518ce1bd9370fac5b6", size = 511009, upload-time = "2025-11-09T20:48:45.726Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/51/2cb4468b3448a8385ebcd15059d325c9ce67df4e2758d133ab9442b19834/jiter-0.12.0-cp314-cp314t-win32.whl", hash = "sha256:8bbcfe2791dfdb7c5e48baf646d37a6a3dcb5a97a032017741dea9f817dca183", size = 205110, upload-time = "2025-11-09T20:48:47.033Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c5/ae5ec83dec9c2d1af805fd5fe8f74ebded9c8670c5210ec7820ce0dbeb1e/jiter-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2fa940963bf02e1d8226027ef461e36af472dea85d36054ff835aeed944dd873", size = 205223, upload-time = "2025-11-09T20:48:49.076Z" },
-    { url = "https://files.pythonhosted.org/packages/97/9a/3c5391907277f0e55195550cf3fa8e293ae9ee0c00fb402fec1e38c0c82f/jiter-0.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:506c9708dd29b27288f9f8f1140c3cb0e3d8ddb045956d7757b1fa0e0f39a473", size = 185564, upload-time = "2025-11-09T20:48:50.376Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/f5/12efb8ada5f5c9edc1d4555fe383c1fb2eac05ac5859258a72d61981d999/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e8547883d7b96ef2e5fe22b88f8a4c8725a56e7f4abafff20fd5272d634c7ecb", size = 309974, upload-time = "2025-11-09T20:49:17.187Z" },
-    { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -923,29 +576,6 @@ wheels = [
 ]
 
 [[package]]
-name = "litellm"
-version = "1.80.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
-]
-
-[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -972,14 +602,16 @@ dependencies = [
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
     { name = "imapclient" },
-    { name = "litellm" },
     { name = "loguru" },
-    { name = "ollama" },
+    { name = "mlx" },
+    { name = "mlx-lm" },
+    { name = "numpy" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pytest-mock" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "sentence-transformers" },
     { name = "streamlit" },
     { name = "watchdog" },
 ]
@@ -1018,9 +650,10 @@ requires-dist = [
     { name = "google-auth-oauthlib", specifier = "==1.2.2" },
     { name = "google-auth-oauthlib", marker = "extra == 'gmail'" },
     { name = "imapclient", specifier = ">=3.0.1" },
-    { name = "litellm", specifier = ">=1.73.6" },
     { name = "loguru", specifier = ">=0.7.2" },
-    { name = "ollama", specifier = ">=0.3.0" },
+    { name = "mlx", specifier = ">=0.18.0" },
+    { name = "mlx-lm", specifier = ">=0.18.0" },
+    { name = "numpy", specifier = ">=1.24.0" },
     { name = "pendulum", marker = "extra == 'dev'" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pydantic", specifier = "==2.11.7" },
@@ -1032,6 +665,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "sentence-transformers", specifier = ">=2.2.0" },
     { name = "streamlit", specifier = ">=1.46.1" },
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "yamlfix", marker = "extra == 'dev'" },
@@ -1139,102 +773,65 @@ wheels = [
 ]
 
 [[package]]
-name = "multidict"
-version = "6.7.0"
+name = "mlx"
+version = "0.30.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/80/1e/5492c365f222f907de1039b91f922b93fa4f764c713ee858d235495d8f50/multidict-6.7.0.tar.gz", hash = "sha256:c6e99d9a65ca282e578dfea819cfa9c0a62b2499d8677392e09feaf305e9e6f5", size = 101834, upload-time = "2025-10-06T14:52:30.657Z" }
+dependencies = [
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/9e/9f61ac18d9c8b475889f32ccfa91c9f59363480613fc807b6e3023d6f60b/multidict-6.7.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8a3862568a36d26e650a19bb5cbbba14b71789032aebc0423f8cc5f150730184", size = 76877, upload-time = "2025-10-06T14:49:20.884Z" },
-    { url = "https://files.pythonhosted.org/packages/38/6f/614f09a04e6184f8824268fce4bc925e9849edfa654ddd59f0b64508c595/multidict-6.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:960c60b5849b9b4f9dcc9bea6e3626143c252c74113df2c1540aebce70209b45", size = 45467, upload-time = "2025-10-06T14:49:22.054Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/93/c4f67a436dd026f2e780c433277fff72be79152894d9fc36f44569cab1a6/multidict-6.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2049be98fb57a31b4ccf870bf377af2504d4ae35646a19037ec271e4c07998aa", size = 43834, upload-time = "2025-10-06T14:49:23.566Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/f5/013798161ca665e4a422afbc5e2d9e4070142a9ff8905e482139cd09e4d0/multidict-6.7.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0934f3843a1860dd465d38895c17fce1f1cb37295149ab05cd1b9a03afacb2a7", size = 250545, upload-time = "2025-10-06T14:49:24.882Z" },
-    { url = "https://files.pythonhosted.org/packages/71/2f/91dbac13e0ba94669ea5119ba267c9a832f0cb65419aca75549fcf09a3dc/multidict-6.7.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3e34f3a1b8131ba06f1a73adab24f30934d148afcd5f5de9a73565a4404384e", size = 258305, upload-time = "2025-10-06T14:49:26.778Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/b0/754038b26f6e04488b48ac621f779c341338d78503fb45403755af2df477/multidict-6.7.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:efbb54e98446892590dc2458c19c10344ee9a883a79b5cec4bc34d6656e8d546", size = 242363, upload-time = "2025-10-06T14:49:28.562Z" },
-    { url = "https://files.pythonhosted.org/packages/87/15/9da40b9336a7c9fa606c4cf2ed80a649dffeb42b905d4f63a1d7eb17d746/multidict-6.7.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a35c5fc61d4f51eb045061e7967cfe3123d622cd500e8868e7c0c592a09fedc4", size = 268375, upload-time = "2025-10-06T14:49:29.96Z" },
-    { url = "https://files.pythonhosted.org/packages/82/72/c53fcade0cc94dfaad583105fd92b3a783af2091eddcb41a6d5a52474000/multidict-6.7.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29fe6740ebccba4175af1b9b87bf553e9c15cd5868ee967e010efcf94e4fd0f1", size = 269346, upload-time = "2025-10-06T14:49:31.404Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/e2/9baffdae21a76f77ef8447f1a05a96ec4bc0a24dae08767abc0a2fe680b8/multidict-6.7.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:123e2a72e20537add2f33a79e605f6191fba2afda4cbb876e35c1a7074298a7d", size = 256107, upload-time = "2025-10-06T14:49:32.974Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/06/3f06f611087dc60d65ef775f1fb5aca7c6d61c6db4990e7cda0cef9b1651/multidict-6.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b284e319754366c1aee2267a2036248b24eeb17ecd5dc16022095e747f2f4304", size = 253592, upload-time = "2025-10-06T14:49:34.52Z" },
-    { url = "https://files.pythonhosted.org/packages/20/24/54e804ec7945b6023b340c412ce9c3f81e91b3bf5fa5ce65558740141bee/multidict-6.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:803d685de7be4303b5a657b76e2f6d1240e7e0a8aa2968ad5811fa2285553a12", size = 251024, upload-time = "2025-10-06T14:49:35.956Z" },
-    { url = "https://files.pythonhosted.org/packages/14/48/011cba467ea0b17ceb938315d219391d3e421dfd35928e5dbdc3f4ae76ef/multidict-6.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c04a328260dfd5db8c39538f999f02779012268f54614902d0afc775d44e0a62", size = 251484, upload-time = "2025-10-06T14:49:37.631Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2f/919258b43bb35b99fa127435cfb2d91798eb3a943396631ef43e3720dcf4/multidict-6.7.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8a19cdb57cd3df4cd865849d93ee14920fb97224300c88501f16ecfa2604b4e0", size = 263579, upload-time = "2025-10-06T14:49:39.502Z" },
-    { url = "https://files.pythonhosted.org/packages/31/22/a0e884d86b5242b5a74cf08e876bdf299e413016b66e55511f7a804a366e/multidict-6.7.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9b2fd74c52accced7e75de26023b7dccee62511a600e62311b918ec5c168fc2a", size = 259654, upload-time = "2025-10-06T14:49:41.32Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/e5/17e10e1b5c5f5a40f2fcbb45953c9b215f8a4098003915e46a93f5fcaa8f/multidict-6.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3e8bfdd0e487acf992407a140d2589fe598238eaeffa3da8448d63a63cd363f8", size = 251511, upload-time = "2025-10-06T14:49:46.021Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/9a/201bb1e17e7af53139597069c375e7b0dcbd47594604f65c2d5359508566/multidict-6.7.0-cp312-cp312-win32.whl", hash = "sha256:dd32a49400a2c3d52088e120ee00c1e3576cbff7e10b98467962c74fdb762ed4", size = 41895, upload-time = "2025-10-06T14:49:48.718Z" },
-    { url = "https://files.pythonhosted.org/packages/46/e2/348cd32faad84eaf1d20cce80e2bb0ef8d312c55bca1f7fa9865e7770aaf/multidict-6.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:92abb658ef2d7ef22ac9f8bb88e8b6c3e571671534e029359b6d9e845923eb1b", size = 46073, upload-time = "2025-10-06T14:49:50.28Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ec/aad2613c1910dce907480e0c3aa306905830f25df2e54ccc9dea450cb5aa/multidict-6.7.0-cp312-cp312-win_arm64.whl", hash = "sha256:490dab541a6a642ce1a9d61a4781656b346a55c13038f0b1244653828e3a83ec", size = 43226, upload-time = "2025-10-06T14:49:52.304Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/86/33272a544eeb36d66e4d9a920602d1a2f57d4ebea4ef3cdfe5a912574c95/multidict-6.7.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bee7c0588aa0076ce77c0ea5d19a68d76ad81fcd9fe8501003b9a24f9d4000f6", size = 76135, upload-time = "2025-10-06T14:49:54.26Z" },
-    { url = "https://files.pythonhosted.org/packages/91/1c/eb97db117a1ebe46d457a3d235a7b9d2e6dcab174f42d1b67663dd9e5371/multidict-6.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7ef6b61cad77091056ce0e7ce69814ef72afacb150b7ac6a3e9470def2198159", size = 45117, upload-time = "2025-10-06T14:49:55.82Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/d8/6c3442322e41fb1dd4de8bd67bfd11cd72352ac131f6368315617de752f1/multidict-6.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9c0359b1ec12b1d6849c59f9d319610b7f20ef990a6d454ab151aa0e3b9f78ca", size = 43472, upload-time = "2025-10-06T14:49:57.048Z" },
-    { url = "https://files.pythonhosted.org/packages/75/3f/e2639e80325af0b6c6febdf8e57cc07043ff15f57fa1ef808f4ccb5ac4cd/multidict-6.7.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cd240939f71c64bd658f186330603aac1a9a81bf6273f523fca63673cb7378a8", size = 249342, upload-time = "2025-10-06T14:49:58.368Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/cc/84e0585f805cbeaa9cbdaa95f9a3d6aed745b9d25700623ac89a6ecff400/multidict-6.7.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60a4d75718a5efa473ebd5ab685786ba0c67b8381f781d1be14da49f1a2dc60", size = 257082, upload-time = "2025-10-06T14:49:59.89Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/9c/ac851c107c92289acbbf5cfb485694084690c1b17e555f44952c26ddc5bd/multidict-6.7.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53a42d364f323275126aff81fb67c5ca1b7a04fda0546245730a55c8c5f24bc4", size = 240704, upload-time = "2025-10-06T14:50:01.485Z" },
-    { url = "https://files.pythonhosted.org/packages/50/cc/5f93e99427248c09da95b62d64b25748a5f5c98c7c2ab09825a1d6af0e15/multidict-6.7.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3b29b980d0ddbecb736735ee5bef69bb2ddca56eff603c86f3f29a1128299b4f", size = 266355, upload-time = "2025-10-06T14:50:02.955Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0c/2ec1d883ceb79c6f7f6d7ad90c919c898f5d1c6ea96d322751420211e072/multidict-6.7.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f8a93b1c0ed2d04b97a5e9336fd2d33371b9a6e29ab7dd6503d63407c20ffbaf", size = 267259, upload-time = "2025-10-06T14:50:04.446Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/2d/f0b184fa88d6630aa267680bdb8623fb69cb0d024b8c6f0d23f9a0f406d3/multidict-6.7.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ff96e8815eecacc6645da76c413eb3b3d34cfca256c70b16b286a687d013c32", size = 254903, upload-time = "2025-10-06T14:50:05.98Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c9/11ea263ad0df7dfabcad404feb3c0dd40b131bc7f232d5537f2fb1356951/multidict-6.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7516c579652f6a6be0e266aec0acd0db80829ca305c3d771ed898538804c2036", size = 252365, upload-time = "2025-10-06T14:50:07.511Z" },
-    { url = "https://files.pythonhosted.org/packages/41/88/d714b86ee2c17d6e09850c70c9d310abac3d808ab49dfa16b43aba9d53fd/multidict-6.7.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:040f393368e63fb0f3330e70c26bfd336656bed925e5cbe17c9da839a6ab13ec", size = 250062, upload-time = "2025-10-06T14:50:09.074Z" },
-    { url = "https://files.pythonhosted.org/packages/15/fe/ad407bb9e818c2b31383f6131ca19ea7e35ce93cf1310fce69f12e89de75/multidict-6.7.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b3bc26a951007b1057a1c543af845f1c7e3e71cc240ed1ace7bf4484aa99196e", size = 249683, upload-time = "2025-10-06T14:50:10.714Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/a4/a89abdb0229e533fb925e7c6e5c40201c2873efebc9abaf14046a4536ee6/multidict-6.7.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7b022717c748dd1992a83e219587aabe45980d88969f01b316e78683e6285f64", size = 261254, upload-time = "2025-10-06T14:50:12.28Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/aa/0e2b27bd88b40a4fb8dc53dd74eecac70edaa4c1dd0707eb2164da3675b3/multidict-6.7.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:9600082733859f00d79dee64effc7aef1beb26adb297416a4ad2116fd61374bd", size = 257967, upload-time = "2025-10-06T14:50:14.16Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/8e/0c67b7120d5d5f6d874ed85a085f9dc770a7f9d8813e80f44a9fec820bb7/multidict-6.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:94218fcec4d72bc61df51c198d098ce2b378e0ccbac41ddbed5ef44092913288", size = 250085, upload-time = "2025-10-06T14:50:15.639Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/55/b73e1d624ea4b8fd4dd07a3bb70f6e4c7c6c5d9d640a41c6ffe5cdbd2a55/multidict-6.7.0-cp313-cp313-win32.whl", hash = "sha256:a37bd74c3fa9d00be2d7b8eca074dc56bd8077ddd2917a839bd989612671ed17", size = 41713, upload-time = "2025-10-06T14:50:17.066Z" },
-    { url = "https://files.pythonhosted.org/packages/32/31/75c59e7d3b4205075b4c183fa4ca398a2daf2303ddf616b04ae6ef55cffe/multidict-6.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:30d193c6cc6d559db42b6bcec8a5d395d34d60c9877a0b71ecd7c204fcf15390", size = 45915, upload-time = "2025-10-06T14:50:18.264Z" },
-    { url = "https://files.pythonhosted.org/packages/31/2a/8987831e811f1184c22bc2e45844934385363ee61c0a2dcfa8f71b87e608/multidict-6.7.0-cp313-cp313-win_arm64.whl", hash = "sha256:ea3334cabe4d41b7ccd01e4d349828678794edbc2d3ae97fc162a3312095092e", size = 43077, upload-time = "2025-10-06T14:50:19.853Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/68/7b3a5170a382a340147337b300b9eb25a9ddb573bcdfff19c0fa3f31ffba/multidict-6.7.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ad9ce259f50abd98a1ca0aa6e490b58c316a0fce0617f609723e40804add2c00", size = 83114, upload-time = "2025-10-06T14:50:21.223Z" },
-    { url = "https://files.pythonhosted.org/packages/55/5c/3fa2d07c84df4e302060f555bbf539310980362236ad49f50eeb0a1c1eb9/multidict-6.7.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07f5594ac6d084cbb5de2df218d78baf55ef150b91f0ff8a21cc7a2e3a5a58eb", size = 48442, upload-time = "2025-10-06T14:50:22.871Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/56/67212d33239797f9bd91962bb899d72bb0f4c35a8652dcdb8ed049bef878/multidict-6.7.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0591b48acf279821a579282444814a2d8d0af624ae0bc600aa4d1b920b6e924b", size = 46885, upload-time = "2025-10-06T14:50:24.258Z" },
-    { url = "https://files.pythonhosted.org/packages/46/d1/908f896224290350721597a61a69cd19b89ad8ee0ae1f38b3f5cd12ea2ac/multidict-6.7.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:749a72584761531d2b9467cfbdfd29487ee21124c304c4b6cb760d8777b27f9c", size = 242588, upload-time = "2025-10-06T14:50:25.716Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/67/8604288bbd68680eee0ab568fdcb56171d8b23a01bcd5cb0c8fedf6e5d99/multidict-6.7.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b4c3d199f953acd5b446bf7c0de1fe25d94e09e79086f8dc2f48a11a129cdf1", size = 249966, upload-time = "2025-10-06T14:50:28.192Z" },
-    { url = "https://files.pythonhosted.org/packages/20/33/9228d76339f1ba51e3efef7da3ebd91964d3006217aae13211653193c3ff/multidict-6.7.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9fb0211dfc3b51efea2f349ec92c114d7754dd62c01f81c3e32b765b70c45c9b", size = 228618, upload-time = "2025-10-06T14:50:29.82Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/2d/25d9b566d10cab1c42b3b9e5b11ef79c9111eaf4463b8c257a3bd89e0ead/multidict-6.7.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a027ec240fe73a8d6281872690b988eed307cd7d91b23998ff35ff577ca688b5", size = 257539, upload-time = "2025-10-06T14:50:31.731Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/b1/8d1a965e6637fc33de3c0d8f414485c2b7e4af00f42cab3d84e7b955c222/multidict-6.7.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1d964afecdf3a8288789df2f5751dc0a8261138c3768d9af117ed384e538fad", size = 256345, upload-time = "2025-10-06T14:50:33.26Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/0c/06b5a8adbdeedada6f4fb8d8f193d44a347223b11939b42953eeb6530b6b/multidict-6.7.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:caf53b15b1b7df9fbd0709aa01409000a2b4dd03a5f6f5cc548183c7c8f8b63c", size = 247934, upload-time = "2025-10-06T14:50:34.808Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/31/b2491b5fe167ca044c6eb4b8f2c9f3b8a00b24c432c365358eadac5d7625/multidict-6.7.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:654030da3197d927f05a536a66186070e98765aa5142794c9904555d3a9d8fb5", size = 245243, upload-time = "2025-10-06T14:50:36.436Z" },
-    { url = "https://files.pythonhosted.org/packages/61/1a/982913957cb90406c8c94f53001abd9eafc271cb3e70ff6371590bec478e/multidict-6.7.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:2090d3718829d1e484706a2f525e50c892237b2bf9b17a79b059cb98cddc2f10", size = 235878, upload-time = "2025-10-06T14:50:37.953Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c0/21435d804c1a1cf7a2608593f4d19bca5bcbd7a81a70b253fdd1c12af9c0/multidict-6.7.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:2d2cfeec3f6f45651b3d408c4acec0ebf3daa9bc8a112a084206f5db5d05b754", size = 243452, upload-time = "2025-10-06T14:50:39.574Z" },
-    { url = "https://files.pythonhosted.org/packages/54/0a/4349d540d4a883863191be6eb9a928846d4ec0ea007d3dcd36323bb058ac/multidict-6.7.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:4ef089f985b8c194d341eb2c24ae6e7408c9a0e2e5658699c92f497437d88c3c", size = 252312, upload-time = "2025-10-06T14:50:41.612Z" },
-    { url = "https://files.pythonhosted.org/packages/26/64/d5416038dbda1488daf16b676e4dbfd9674dde10a0cc8f4fc2b502d8125d/multidict-6.7.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e93a0617cd16998784bf4414c7e40f17a35d2350e5c6f0bd900d3a8e02bd3762", size = 246935, upload-time = "2025-10-06T14:50:43.972Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/8c/8290c50d14e49f35e0bd4abc25e1bc7711149ca9588ab7d04f886cdf03d9/multidict-6.7.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f0feece2ef8ebc42ed9e2e8c78fc4aa3cf455733b507c09ef7406364c94376c6", size = 243385, upload-time = "2025-10-06T14:50:45.648Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/a0/f83ae75e42d694b3fbad3e047670e511c138be747bc713cf1b10d5096416/multidict-6.7.0-cp313-cp313t-win32.whl", hash = "sha256:19a1d55338ec1be74ef62440ca9e04a2f001a04d0cc49a4983dc320ff0f3212d", size = 47777, upload-time = "2025-10-06T14:50:47.154Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/80/9b174a92814a3830b7357307a792300f42c9e94664b01dee8e457551fa66/multidict-6.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3da4fb467498df97e986af166b12d01f05d2e04f978a9c1c680ea1988e0bc4b6", size = 53104, upload-time = "2025-10-06T14:50:48.851Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/28/04baeaf0428d95bb7a7bea0e691ba2f31394338ba424fb0679a9ed0f4c09/multidict-6.7.0-cp313-cp313t-win_arm64.whl", hash = "sha256:b4121773c49a0776461f4a904cdf6264c88e42218aaa8407e803ca8025872792", size = 45503, upload-time = "2025-10-06T14:50:50.16Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/b1/3da6934455dd4b261d4c72f897e3a5728eba81db59959f3a639245891baa/multidict-6.7.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3bab1e4aff7adaa34410f93b1f8e57c4b36b9af0426a76003f441ee1d3c7e842", size = 75128, upload-time = "2025-10-06T14:50:51.92Z" },
-    { url = "https://files.pythonhosted.org/packages/14/2c/f069cab5b51d175a1a2cb4ccdf7a2c2dabd58aa5bd933fa036a8d15e2404/multidict-6.7.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b8512bac933afc3e45fb2b18da8e59b78d4f408399a960339598374d4ae3b56b", size = 44410, upload-time = "2025-10-06T14:50:53.275Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e2/64bb41266427af6642b6b128e8774ed84c11b80a90702c13ac0a86bb10cc/multidict-6.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:79dcf9e477bc65414ebfea98ffd013cb39552b5ecd62908752e0e413d6d06e38", size = 43205, upload-time = "2025-10-06T14:50:54.911Z" },
-    { url = "https://files.pythonhosted.org/packages/02/68/6b086fef8a3f1a8541b9236c594f0c9245617c29841f2e0395d979485cde/multidict-6.7.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:31bae522710064b5cbeddaf2e9f32b1abab70ac6ac91d42572502299e9953128", size = 245084, upload-time = "2025-10-06T14:50:56.369Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ee/f524093232007cd7a75c1d132df70f235cfd590a7c9eaccd7ff422ef4ae8/multidict-6.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a0df7ff02397bb63e2fd22af2c87dfa39e8c7f12947bc524dbdc528282c7e34", size = 252667, upload-time = "2025-10-06T14:50:57.991Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a5/eeb3f43ab45878f1895118c3ef157a480db58ede3f248e29b5354139c2c9/multidict-6.7.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7a0222514e8e4c514660e182d5156a415c13ef0aabbd71682fc714e327b95e99", size = 233590, upload-time = "2025-10-06T14:50:59.589Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1e/76d02f8270b97269d7e3dbd45644b1785bda457b474315f8cf999525a193/multidict-6.7.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2397ab4daaf2698eb51a76721e98db21ce4f52339e535725de03ea962b5a3202", size = 264112, upload-time = "2025-10-06T14:51:01.183Z" },
-    { url = "https://files.pythonhosted.org/packages/76/0b/c28a70ecb58963847c2a8efe334904cd254812b10e535aefb3bcce513918/multidict-6.7.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8891681594162635948a636c9fe0ff21746aeb3dd5463f6e25d9bea3a8a39ca1", size = 261194, upload-time = "2025-10-06T14:51:02.794Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/63/2ab26e4209773223159b83aa32721b4021ffb08102f8ac7d689c943fded1/multidict-6.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18706cc31dbf402a7945916dd5cddf160251b6dab8a2c5f3d6d5a55949f676b3", size = 248510, upload-time = "2025-10-06T14:51:04.724Z" },
-    { url = "https://files.pythonhosted.org/packages/93/cd/06c1fa8282af1d1c46fd55c10a7930af652afdce43999501d4d68664170c/multidict-6.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f844a1bbf1d207dd311a56f383f7eda2d0e134921d45751842d8235e7778965d", size = 248395, upload-time = "2025-10-06T14:51:06.306Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ac/82cb419dd6b04ccf9e7e61befc00c77614fc8134362488b553402ecd55ce/multidict-6.7.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4393e3581e84e5645506923816b9cc81f5609a778c7e7534054091acc64d1c6", size = 239520, upload-time = "2025-10-06T14:51:08.091Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f3/a0f9bf09493421bd8716a362e0cd1d244f5a6550f5beffdd6b47e885b331/multidict-6.7.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:fbd18dc82d7bf274b37aa48d664534330af744e03bccf696d6f4c6042e7d19e7", size = 245479, upload-time = "2025-10-06T14:51:10.365Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/01/476d38fc73a212843f43c852b0eee266b6971f0e28329c2184a8df90c376/multidict-6.7.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b6234e14f9314731ec45c42fc4554b88133ad53a09092cc48a88e771c125dadb", size = 258903, upload-time = "2025-10-06T14:51:12.466Z" },
-    { url = "https://files.pythonhosted.org/packages/49/6d/23faeb0868adba613b817d0e69c5f15531b24d462af8012c4f6de4fa8dc3/multidict-6.7.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:08d4379f9744d8f78d98c8673c06e202ffa88296f009c71bbafe8a6bf847d01f", size = 252333, upload-time = "2025-10-06T14:51:14.48Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/48d02ac22b30fa247f7dad82866e4b1015431092f4ba6ebc7e77596e0b18/multidict-6.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9fe04da3f79387f450fd0061d4dd2e45a72749d31bf634aecc9e27f24fdc4b3f", size = 243411, upload-time = "2025-10-06T14:51:16.072Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/03/29a8bf5a18abf1fe34535c88adbdfa88c9fb869b5a3b120692c64abe8284/multidict-6.7.0-cp314-cp314-win32.whl", hash = "sha256:fbafe31d191dfa7c4c51f7a6149c9fb7e914dcf9ffead27dcfd9f1ae382b3885", size = 40940, upload-time = "2025-10-06T14:51:17.544Z" },
-    { url = "https://files.pythonhosted.org/packages/82/16/7ed27b680791b939de138f906d5cf2b4657b0d45ca6f5dd6236fdddafb1a/multidict-6.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:2f67396ec0310764b9222a1728ced1ab638f61aadc6226f17a71dd9324f9a99c", size = 45087, upload-time = "2025-10-06T14:51:18.875Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/3c/e3e62eb35a1950292fe39315d3c89941e30a9d07d5d2df42965ab041da43/multidict-6.7.0-cp314-cp314-win_arm64.whl", hash = "sha256:ba672b26069957ee369cfa7fc180dde1fc6f176eaf1e6beaf61fbebbd3d9c000", size = 42368, upload-time = "2025-10-06T14:51:20.225Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/40/cd499bd0dbc5f1136726db3153042a735fffd0d77268e2ee20d5f33c010f/multidict-6.7.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:c1dcc7524066fa918c6a27d61444d4ee7900ec635779058571f70d042d86ed63", size = 82326, upload-time = "2025-10-06T14:51:21.588Z" },
-    { url = "https://files.pythonhosted.org/packages/13/8a/18e031eca251c8df76daf0288e6790561806e439f5ce99a170b4af30676b/multidict-6.7.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:27e0b36c2d388dc7b6ced3406671b401e84ad7eb0656b8f3a2f46ed0ce483718", size = 48065, upload-time = "2025-10-06T14:51:22.93Z" },
-    { url = "https://files.pythonhosted.org/packages/40/71/5e6701277470a87d234e433fb0a3a7deaf3bcd92566e421e7ae9776319de/multidict-6.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2a7baa46a22e77f0988e3b23d4ede5513ebec1929e34ee9495be535662c0dfe2", size = 46475, upload-time = "2025-10-06T14:51:24.352Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/6a/bab00cbab6d9cfb57afe1663318f72ec28289ea03fd4e8236bb78429893a/multidict-6.7.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7bf77f54997a9166a2f5675d1201520586439424c2511723a7312bdb4bcc034e", size = 239324, upload-time = "2025-10-06T14:51:25.822Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/5f/8de95f629fc22a7769ade8b41028e3e5a822c1f8904f618d175945a81ad3/multidict-6.7.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e011555abada53f1578d63389610ac8a5400fc70ce71156b0aa30d326f1a5064", size = 246877, upload-time = "2025-10-06T14:51:27.604Z" },
-    { url = "https://files.pythonhosted.org/packages/23/b4/38881a960458f25b89e9f4a4fdcb02ac101cfa710190db6e5528841e67de/multidict-6.7.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:28b37063541b897fd6a318007373930a75ca6d6ac7c940dbe14731ffdd8d498e", size = 225824, upload-time = "2025-10-06T14:51:29.664Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/39/6566210c83f8a261575f18e7144736059f0c460b362e96e9cf797a24b8e7/multidict-6.7.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05047ada7a2fde2631a0ed706f1fd68b169a681dfe5e4cf0f8e4cb6618bbc2cd", size = 253558, upload-time = "2025-10-06T14:51:31.684Z" },
-    { url = "https://files.pythonhosted.org/packages/00/a3/67f18315100f64c269f46e6c0319fa87ba68f0f64f2b8e7fd7c72b913a0b/multidict-6.7.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:716133f7d1d946a4e1b91b1756b23c088881e70ff180c24e864c26192ad7534a", size = 252339, upload-time = "2025-10-06T14:51:33.699Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/2a/1cb77266afee2458d82f50da41beba02159b1d6b1f7973afc9a1cad1499b/multidict-6.7.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d1bed1b467ef657f2a0ae62844a607909ef1c6889562de5e1d505f74457d0b96", size = 244895, upload-time = "2025-10-06T14:51:36.189Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/72/09fa7dd487f119b2eb9524946ddd36e2067c08510576d43ff68469563b3b/multidict-6.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ca43bdfa5d37bd6aee89d85e1d0831fb86e25541be7e9d376ead1b28974f8e5e", size = 241862, upload-time = "2025-10-06T14:51:41.291Z" },
-    { url = "https://files.pythonhosted.org/packages/65/92/bc1f8bd0853d8669300f732c801974dfc3702c3eeadae2f60cef54dc69d7/multidict-6.7.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:44b546bd3eb645fd26fb949e43c02a25a2e632e2ca21a35e2e132c8105dc8599", size = 232376, upload-time = "2025-10-06T14:51:43.55Z" },
-    { url = "https://files.pythonhosted.org/packages/09/86/ac39399e5cb9d0c2ac8ef6e10a768e4d3bc933ac808d49c41f9dc23337eb/multidict-6.7.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:a6ef16328011d3f468e7ebc326f24c1445f001ca1dec335b2f8e66bed3006394", size = 240272, upload-time = "2025-10-06T14:51:45.265Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b6/fed5ac6b8563ec72df6cb1ea8dac6d17f0a4a1f65045f66b6d3bf1497c02/multidict-6.7.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5aa873cbc8e593d361ae65c68f85faadd755c3295ea2c12040ee146802f23b38", size = 248774, upload-time = "2025-10-06T14:51:46.836Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8d/b954d8c0dc132b68f760aefd45870978deec6818897389dace00fcde32ff/multidict-6.7.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3d7b6ccce016e29df4b7ca819659f516f0bc7a4b3efa3bb2012ba06431b044f9", size = 242731, upload-time = "2025-10-06T14:51:48.541Z" },
-    { url = "https://files.pythonhosted.org/packages/16/9d/a2dac7009125d3540c2f54e194829ea18ac53716c61b655d8ed300120b0f/multidict-6.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:171b73bd4ee683d307599b66793ac80981b06f069b62eea1c9e29c9241aa66b0", size = 240193, upload-time = "2025-10-06T14:51:50.355Z" },
-    { url = "https://files.pythonhosted.org/packages/39/ca/c05f144128ea232ae2178b008d5011d4e2cea86e4ee8c85c2631b1b94802/multidict-6.7.0-cp314-cp314t-win32.whl", hash = "sha256:b2d7f80c4e1fd010b07cb26820aae86b7e73b681ee4889684fb8d2d4537aab13", size = 48023, upload-time = "2025-10-06T14:51:51.883Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/8f/0a60e501584145588be1af5cc829265701ba3c35a64aec8e07cbb71d39bb/multidict-6.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:09929cab6fcb68122776d575e03c6cc64ee0b8fca48d17e135474b042ce515cd", size = 53507, upload-time = "2025-10-06T14:51:53.672Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/ae/3148b988a9c6239903e786eac19c889fab607c31d6efa7fb2147e5680f23/multidict-6.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:cc41db090ed742f32bd2d2c721861725e6109681eddf835d0a82bd3a5c382827", size = 44804, upload-time = "2025-10-06T14:51:55.415Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/da/7d22601b625e241d4f23ef1ebff8acfc60da633c9e7e7922e24d10f592b3/multidict-6.7.0-py3-none-any.whl", hash = "sha256:394fc5c42a333c9ffc3e421a4c85e08580d990e08b99f6bf35b4132114c5dcb3", size = 12317, upload-time = "2025-10-06T14:52:29.272Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/4b/ad57b2f0ede3f0d009c0e3e1270c219bd18f9025388855ee149680cffa20/mlx-0.30.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:deaef3ecd2f99930867a29de748e3bffa9cc7e4dfa834f2501c37ed29aece1cc", size = 593397, upload-time = "2025-12-18T01:55:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/14/7fa03a0f66ac3cfb2fd6752178a1488f13c7233fff26eed0f832d961db35/mlx-0.30.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:86ccdcda0b5ea4768b87da25beae5b83ac7cc802506116b6845cea6f450e2377", size = 593397, upload-time = "2025-12-18T01:55:43Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c8/9f1343dbe2381f9653df4e0a62dc8bf38f575a2553dc2aa6916de32d2a85/mlx-0.30.1-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:a625cb434b2acc5674fe10683374641dab9671fb354ae7c2c67a1fb0405eeb37", size = 567576, upload-time = "2025-12-18T00:15:55.114Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/485ed9c99c18ef89ac987178c0a526cb4148ba38b14838d315311d9d76a8/mlx-0.30.1-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:ccc1ff3aca8fb1073c7dcd1274cebe48ae75f852d14b16c7db8228fbbad594dd", size = 643654, upload-time = "2025-12-18T01:55:44.165Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d3/54d3bf5e404c3b6424b49c505dc8b3c06c6bb498fe720195b1fafbd69b5e/mlx-0.30.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:55ed7fc4b389d6e49dac6d34a97b41e61cbe3662ac29c3d29cf612e6b2ed9827", size = 687305, upload-time = "2025-12-18T01:55:45.526Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fd/c6f56cd87d48763ed63655ace627c06db9819eae7d43d132f40d4965947a/mlx-0.30.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:743520758bc8261b2ed8f3b3dc96e4e9236769dd8f61fb17877c5e44037e2058", size = 593366, upload-time = "2025-12-18T01:55:46.786Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/53/96d8c48b21f91c4216b6d2ef6dfc10862e5fb0b811a2aaf02c96c78601de/mlx-0.30.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:fc9745bc1860ca60128e3a6d36157da06d936e2b4007a4dcba990b40202f598f", size = 593368, upload-time = "2025-12-18T01:55:48.363Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ce/476c3b7d3a4153bd0e1c5af1f1b6c09a804b652bbed34072404b322c22e0/mlx-0.30.1-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:a1480399c67bb327a66c5527b73915132e3fcaae3bce9634e5c81ccad9f43229", size = 567561, upload-time = "2025-12-18T00:15:56.153Z" },
+    { url = "https://files.pythonhosted.org/packages/33/41/7ad1e639fd7dd1cf01a62c1c5b051024a859888c27504996e9d8380e6754/mlx-0.30.1-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:8e19850a4236a8e174f851f5789b8b62a8eb74f5a8fa49ad8ba286c5ddb5f9bf", size = 643122, upload-time = "2025-12-18T01:55:49.607Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/dc/72d3737c5b0662eb5e785d353dbc5e34d793d27b09b99e39993ee051bd19/mlx-0.30.1-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:1c8ed5bcd9f1910fca209e95859ac737e60b3e1954181b820fa269158f81049a", size = 687254, upload-time = "2025-12-18T01:55:51.239Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/cc/523448996247bb05d9d68e23bccf3dafdda660befb9330f6bd5fa13361e8/mlx-0.30.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d34cc2c25b0ee41c1349f14650db760e282685339858e305453f62405c12bc1b", size = 596006, upload-time = "2025-12-18T01:55:52.463Z" },
+    { url = "https://files.pythonhosted.org/packages/23/0e/f9f2f9659c34c87be8f4167f6a1d6ed7e826f4889d20eecd4c0d8122f0e9/mlx-0.30.1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:4e47d301e9095b87f0bda8827bfd6ffe744223aba5cee8f28e25894d647f5823", size = 596008, upload-time = "2025-12-18T01:55:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/56/a7/49e41fb141de95b6a376091a963c737839c9cda04e423c67f57460a50458/mlx-0.30.1-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:cfba13e2a52255d663a1ad62f0f83eb3991e42147edf9a8d38cdd224e48ca49b", size = 570406, upload-time = "2025-12-18T00:15:57.177Z" },
+    { url = "https://files.pythonhosted.org/packages/73/99/a43cb112167cf865c069f5e108ae42f5314663930ff3dd86c2d23d984191/mlx-0.30.1-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:bebfec377208eb29cc88aa86c897c7446aa0984838669e138f273f9225d627ff", size = 646461, upload-time = "2025-12-18T01:55:55.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ff/1e1968f107b4221a98dc26832586b1f646b27ddf3e55c95051c09d751f0a/mlx-0.30.1-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:d18012d5cf0f013bc4a405cfd1e9d2d28e798f4d2dc4f15aa0fbffff73c02ba2", size = 687114, upload-time = "2025-12-18T01:55:56.506Z" },
+]
+
+[[package]]
+name = "mlx-lm"
+version = "0.29.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/62/f46e1355256a114808517947f8e83ad6be310c7288c551db0fa678f47923/mlx_lm-0.29.1.tar.gz", hash = "sha256:b99180d8f33d33a077b814e550bfb2d8a59ae003d668fd1f4b3fff62a381d34b", size = 232302, upload-time = "2025-12-16T16:58:27.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/53/913099c91d384e115ea078325efd9a0bc1ea3eb3458c694b4596cbd267f2/mlx_lm-0.29.1-py3-none-any.whl", hash = "sha256:440941b3054c2a2216e97615de584cc90fa1ea874782e20699b9895721fad8dc", size = 324884, upload-time = "2025-12-16T16:58:26.36Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.30.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/3f/0be35ddad7e13d8ecd33a9185895f9739bb00b96ef0cce36cf0405d4aec0/mlx_metal-0.30.1-py3-none-macosx_14_0_arm64.whl", hash = "sha256:e7e92c6bdbd7ac8083f528a4c6640552ae106a57bb3d99856ac10a32e93a4b5e", size = 36864966, upload-time = "2025-12-18T01:55:31.473Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1f/c0bddd0d5bf3871411aabe32121e09e1b7cdbece8917a49d5a442310e3e5/mlx_metal-0.30.1-py3-none-macosx_15_0_arm64.whl", hash = "sha256:bb50f57418af7fc3c42a2da2c4bde0e7ab7ac0b997de1f6f642a6680ac65d626", size = 36859011, upload-time = "2025-12-18T01:55:34.541Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b3/73cc2f584ac612a476096d35a61eed75ee7ed8b4e320b0c36cf60a14d4eb/mlx_metal-0.30.1-py3-none-macosx_26_0_arm64.whl", hash = "sha256:e0b151a0053ac00b4226710bfb6dbf54b87283fb01e10fb3877f9ea969f680aa", size = 44981160, upload-time = "2025-12-18T00:15:47.518Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -1244,6 +841,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/93/f8/e1c28f24b641871c14ccae7ba6381f3c7827789a06e947ce975ae8a9075a/narwhals-2.12.0.tar.gz", hash = "sha256:075b6d56f3a222613793e025744b129439ecdff9292ea6615dd983af7ba6ea44", size = 590404, upload-time = "2025-11-17T10:53:28.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/9a/c6f79de7ba3a0a8473129936b7b90aa461d3d46fec6f1627672b1dccf4e9/narwhals-2.12.0-py3-none-any.whl", hash = "sha256:baeba5d448a30b04c299a696bd9ee5ff73e4742143e06c49ca316b46539a7cbb", size = 425014, upload-time = "2025-11-17T10:53:26.65Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -1310,44 +916,146 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.3.20"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
-]
-
-[[package]]
-name = "ollama"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
-]
-
-[[package]]
-name = "openai"
-version = "2.8.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/e4/42591e356f1d53c568418dc7e30dcda7be31dd5a4d570bca22acb0525862/openai-2.8.1.tar.gz", hash = "sha256:cb1b79eef6e809f6da326a7ef6038719e35aa944c42d081807bfa1be8060f15f", size = 602490, upload-time = "2025-11-17T22:39:59.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/4f/dbc0c124c40cb390508a82770fb9f6e3ed162560181a85089191a851c59a/openai-2.8.1-py3-none-any.whl", hash = "sha256:c6c3b5a04994734386e8dad3c00a393f56d3b68a27cd2e8acae91a59e4122463", size = 1022688, upload-time = "2025-11-17T22:39:57.675Z" },
 ]
 
 [[package]]
@@ -1533,90 +1241,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "propcache"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/0f/f17b1b2b221d5ca28b4b876e8bb046ac40466513960646bda8e1853cdfa2/propcache-0.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e153e9cd40cc8945138822807139367f256f89c6810c2634a4f6902b52d3b4e2", size = 80061, upload-time = "2025-10-08T19:46:46.075Z" },
-    { url = "https://files.pythonhosted.org/packages/76/47/8ccf75935f51448ba9a16a71b783eb7ef6b9ee60f5d14c7f8a8a79fbeed7/propcache-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd547953428f7abb73c5ad82cbb32109566204260d98e41e5dfdc682eb7f8403", size = 46037, upload-time = "2025-10-08T19:46:47.23Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f048da1b4f243fc44f205dfd320933a951b8d89e0afd4c7cacc762a8b9165207", size = 47324, upload-time = "2025-10-08T19:46:48.384Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/d3/6c7ee328b39a81ee877c962469f1e795f9db87f925251efeb0545e0020d0/propcache-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec17c65562a827bba85e3872ead335f95405ea1674860d96483a02f5c698fa72", size = 225505, upload-time = "2025-10-08T19:46:50.055Z" },
-    { url = "https://files.pythonhosted.org/packages/01/5d/1c53f4563490b1d06a684742cc6076ef944bc6457df6051b7d1a877c057b/propcache-0.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:405aac25c6394ef275dee4c709be43745d36674b223ba4eb7144bf4d691b7367", size = 230242, upload-time = "2025-10-08T19:46:51.815Z" },
-    { url = "https://files.pythonhosted.org/packages/20/e1/ce4620633b0e2422207c3cb774a0ee61cac13abc6217763a7b9e2e3f4a12/propcache-0.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0013cb6f8dde4b2a2f66903b8ba740bdfe378c943c4377a200551ceb27f379e4", size = 238474, upload-time = "2025-10-08T19:46:53.208Z" },
-    { url = "https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15932ab57837c3368b024473a525e25d316d8353016e7cc0e5ba9eb343fbb1cf", size = 221575, upload-time = "2025-10-08T19:46:54.511Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/a5/8a5e8678bcc9d3a1a15b9a29165640d64762d424a16af543f00629c87338/propcache-0.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:031dce78b9dc099f4c29785d9cf5577a3faf9ebf74ecbd3c856a7b92768c3df3", size = 216736, upload-time = "2025-10-08T19:46:56.212Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/63/b7b215eddeac83ca1c6b934f89d09a625aa9ee4ba158338854c87210cc36/propcache-0.4.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ab08df6c9a035bee56e31af99be621526bd237bea9f32def431c656b29e41778", size = 213019, upload-time = "2025-10-08T19:46:57.595Z" },
-    { url = "https://files.pythonhosted.org/packages/57/74/f580099a58c8af587cac7ba19ee7cb418506342fbbe2d4a4401661cca886/propcache-0.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4d7af63f9f93fe593afbf104c21b3b15868efb2c21d07d8732c0c4287e66b6a6", size = 220376, upload-time = "2025-10-08T19:46:59.067Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ee/542f1313aff7eaf19c2bb758c5d0560d2683dac001a1c96d0774af799843/propcache-0.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cfc27c945f422e8b5071b6e93169679e4eb5bf73bbcbf1ba3ae3a83d2f78ebd9", size = 226988, upload-time = "2025-10-08T19:47:00.544Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/18/9c6b015dd9c6930f6ce2229e1f02fb35298b847f2087ea2b436a5bfa7287/propcache-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35c3277624a080cc6ec6f847cbbbb5b49affa3598c4535a0a4682a697aaa5c75", size = 215615, upload-time = "2025-10-08T19:47:01.968Z" },
-    { url = "https://files.pythonhosted.org/packages/80/9e/e7b85720b98c45a45e1fca6a177024934dc9bc5f4d5dd04207f216fc33ed/propcache-0.4.1-cp312-cp312-win32.whl", hash = "sha256:671538c2262dadb5ba6395e26c1731e1d52534bfe9ae56d0b5573ce539266aa8", size = 38066, upload-time = "2025-10-08T19:47:03.503Z" },
-    { url = "https://files.pythonhosted.org/packages/54/09/d19cff2a5aaac632ec8fc03737b223597b1e347416934c1b3a7df079784c/propcache-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb2d222e72399fcf5890d1d5cc1060857b9b236adff2792ff48ca2dfd46c81db", size = 41655, upload-time = "2025-10-08T19:47:04.973Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/6b5c191bb5de08036a8c697b265d4ca76148efb10fa162f14af14fb5f076/propcache-0.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:204483131fb222bdaaeeea9f9e6c6ed0cac32731f75dfc1d4a567fc1926477c1", size = 37789, upload-time = "2025-10-08T19:47:06.077Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/df/6d9c1b6ac12b003837dde8a10231a7344512186e87b36e855bef32241942/propcache-0.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:43eedf29202c08550aac1d14e0ee619b0430aaef78f85864c1a892294fbc28cf", size = 77750, upload-time = "2025-10-08T19:47:07.648Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/e8/677a0025e8a2acf07d3418a2e7ba529c9c33caf09d3c1f25513023c1db56/propcache-0.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d62cdfcfd89ccb8de04e0eda998535c406bf5e060ffd56be6c586cbcc05b3311", size = 44780, upload-time = "2025-10-08T19:47:08.851Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a4/92380f7ca60f99ebae761936bc48a72a639e8a47b29050615eef757cb2a7/propcache-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cae65ad55793da34db5f54e4029b89d3b9b9490d8abe1b4c7ab5d4b8ec7ebf74", size = 46308, upload-time = "2025-10-08T19:47:09.982Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/48/c5ac64dee5262044348d1d78a5f85dd1a57464a60d30daee946699963eb3/propcache-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:333ddb9031d2704a301ee3e506dc46b1fe5f294ec198ed6435ad5b6a085facfe", size = 208182, upload-time = "2025-10-08T19:47:11.319Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/0c/cd762dd011a9287389a6a3eb43aa30207bde253610cca06824aeabfe9653/propcache-0.4.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fd0858c20f078a32cf55f7e81473d96dcf3b93fd2ccdb3d40fdf54b8573df3af", size = 211215, upload-time = "2025-10-08T19:47:13.146Z" },
-    { url = "https://files.pythonhosted.org/packages/30/3e/49861e90233ba36890ae0ca4c660e95df565b2cd15d4a68556ab5865974e/propcache-0.4.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:678ae89ebc632c5c204c794f8dab2837c5f159aeb59e6ed0539500400577298c", size = 218112, upload-time = "2025-10-08T19:47:14.913Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/8b/544bc867e24e1bd48f3118cecd3b05c694e160a168478fa28770f22fd094/propcache-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d472aeb4fbf9865e0c6d622d7f4d54a4e101a89715d8904282bb5f9a2f476c3f", size = 204442, upload-time = "2025-10-08T19:47:16.277Z" },
-    { url = "https://files.pythonhosted.org/packages/50/a6/4282772fd016a76d3e5c0df58380a5ea64900afd836cec2c2f662d1b9bb3/propcache-0.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4d3df5fa7e36b3225954fba85589da77a0fe6a53e3976de39caf04a0db4c36f1", size = 199398, upload-time = "2025-10-08T19:47:17.962Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/ec/d8a7cd406ee1ddb705db2139f8a10a8a427100347bd698e7014351c7af09/propcache-0.4.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ee17f18d2498f2673e432faaa71698032b0127ebf23ae5974eeaf806c279df24", size = 196920, upload-time = "2025-10-08T19:47:19.355Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/6c/f38ab64af3764f431e359f8baf9e0a21013e24329e8b85d2da32e8ed07ca/propcache-0.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:580e97762b950f993ae618e167e7be9256b8353c2dcd8b99ec100eb50f5286aa", size = 203748, upload-time = "2025-10-08T19:47:21.338Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/e3/fa846bd70f6534d647886621388f0a265254d30e3ce47e5c8e6e27dbf153/propcache-0.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:501d20b891688eb8e7aa903021f0b72d5a55db40ffaab27edefd1027caaafa61", size = 205877, upload-time = "2025-10-08T19:47:23.059Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/39/8163fc6f3133fea7b5f2827e8eba2029a0277ab2c5beee6c1db7b10fc23d/propcache-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a0bd56e5b100aef69bd8562b74b46254e7c8812918d3baa700c8a8009b0af66", size = 199437, upload-time = "2025-10-08T19:47:24.445Z" },
-    { url = "https://files.pythonhosted.org/packages/93/89/caa9089970ca49c7c01662bd0eeedfe85494e863e8043565aeb6472ce8fe/propcache-0.4.1-cp313-cp313-win32.whl", hash = "sha256:bcc9aaa5d80322bc2fb24bb7accb4a30f81e90ab8d6ba187aec0744bc302ad81", size = 37586, upload-time = "2025-10-08T19:47:25.736Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/ab/f76ec3c3627c883215b5c8080debb4394ef5a7a29be811f786415fc1e6fd/propcache-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:381914df18634f5494334d201e98245c0596067504b9372d8cf93f4bb23e025e", size = 40790, upload-time = "2025-10-08T19:47:26.847Z" },
-    { url = "https://files.pythonhosted.org/packages/59/1b/e71ae98235f8e2ba5004d8cb19765a74877abf189bc53fc0c80d799e56c3/propcache-0.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:8873eb4460fd55333ea49b7d189749ecf6e55bf85080f11b1c4530ed3034cba1", size = 37158, upload-time = "2025-10-08T19:47:27.961Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ce/a31bbdfc24ee0dcbba458c8175ed26089cf109a55bbe7b7640ed2470cfe9/propcache-0.4.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:92d1935ee1f8d7442da9c0c4fa7ac20d07e94064184811b685f5c4fada64553b", size = 81451, upload-time = "2025-10-08T19:47:29.445Z" },
-    { url = "https://files.pythonhosted.org/packages/25/9c/442a45a470a68456e710d96cacd3573ef26a1d0a60067e6a7d5e655621ed/propcache-0.4.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:473c61b39e1460d386479b9b2f337da492042447c9b685f28be4f74d3529e566", size = 46374, upload-time = "2025-10-08T19:47:30.579Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/bf/b1d5e21dbc3b2e889ea4327044fb16312a736d97640fb8b6aa3f9c7b3b65/propcache-0.4.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c0ef0aaafc66fbd87842a3fe3902fd889825646bc21149eafe47be6072725835", size = 48396, upload-time = "2025-10-08T19:47:31.79Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/04/5b4c54a103d480e978d3c8a76073502b18db0c4bc17ab91b3cb5092ad949/propcache-0.4.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95393b4d66bfae908c3ca8d169d5f79cd65636ae15b5e7a4f6e67af675adb0e", size = 275950, upload-time = "2025-10-08T19:47:33.481Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/c1/86f846827fb969c4b78b0af79bba1d1ea2156492e1b83dea8b8a6ae27395/propcache-0.4.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c07fda85708bc48578467e85099645167a955ba093be0a2dcba962195676e859", size = 273856, upload-time = "2025-10-08T19:47:34.906Z" },
-    { url = "https://files.pythonhosted.org/packages/36/1d/fc272a63c8d3bbad6878c336c7a7dea15e8f2d23a544bda43205dfa83ada/propcache-0.4.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:af223b406d6d000830c6f65f1e6431783fc3f713ba3e6cc8c024d5ee96170a4b", size = 280420, upload-time = "2025-10-08T19:47:36.338Z" },
-    { url = "https://files.pythonhosted.org/packages/07/0c/01f2219d39f7e53d52e5173bcb09c976609ba30209912a0680adfb8c593a/propcache-0.4.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a78372c932c90ee474559c5ddfffd718238e8673c340dc21fe45c5b8b54559a0", size = 263254, upload-time = "2025-10-08T19:47:37.692Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/18/cd28081658ce597898f0c4d174d4d0f3c5b6d4dc27ffafeef835c95eb359/propcache-0.4.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:564d9f0d4d9509e1a870c920a89b2fec951b44bf5ba7d537a9e7c1ccec2c18af", size = 261205, upload-time = "2025-10-08T19:47:39.659Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/71/1f9e22eb8b8316701c2a19fa1f388c8a3185082607da8e406a803c9b954e/propcache-0.4.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:17612831fda0138059cc5546f4d12a2aacfb9e47068c06af35c400ba58ba7393", size = 247873, upload-time = "2025-10-08T19:47:41.084Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/65/3d4b61f36af2b4eddba9def857959f1016a51066b4f1ce348e0cf7881f58/propcache-0.4.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:41a89040cb10bd345b3c1a873b2bf36413d48da1def52f268a055f7398514874", size = 262739, upload-time = "2025-10-08T19:47:42.51Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/42/26746ab087faa77c1c68079b228810436ccd9a5ce9ac85e2b7307195fd06/propcache-0.4.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e35b88984e7fa64aacecea39236cee32dd9bd8c55f57ba8a75cf2399553f9bd7", size = 263514, upload-time = "2025-10-08T19:47:43.927Z" },
-    { url = "https://files.pythonhosted.org/packages/94/13/630690fe201f5502d2403dd3cfd451ed8858fe3c738ee88d095ad2ff407b/propcache-0.4.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f8b465489f927b0df505cbe26ffbeed4d6d8a2bbc61ce90eb074ff129ef0ab1", size = 257781, upload-time = "2025-10-08T19:47:45.448Z" },
-    { url = "https://files.pythonhosted.org/packages/92/f7/1d4ec5841505f423469efbfc381d64b7b467438cd5a4bbcbb063f3b73d27/propcache-0.4.1-cp313-cp313t-win32.whl", hash = "sha256:2ad890caa1d928c7c2965b48f3a3815c853180831d0e5503d35cf00c472f4717", size = 41396, upload-time = "2025-10-08T19:47:47.202Z" },
-    { url = "https://files.pythonhosted.org/packages/48/f0/615c30622316496d2cbbc29f5985f7777d3ada70f23370608c1d3e081c1f/propcache-0.4.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f7ee0e597f495cf415bcbd3da3caa3bd7e816b74d0d52b8145954c5e6fd3ff37", size = 44897, upload-time = "2025-10-08T19:47:48.336Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/ca/6002e46eccbe0e33dcd4069ef32f7f1c9e243736e07adca37ae8c4830ec3/propcache-0.4.1-cp313-cp313t-win_arm64.whl", hash = "sha256:929d7cbe1f01bb7baffb33dc14eb5691c95831450a26354cd210a8155170c93a", size = 39789, upload-time = "2025-10-08T19:47:49.876Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/5c/bca52d654a896f831b8256683457ceddd490ec18d9ec50e97dfd8fc726a8/propcache-0.4.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3f7124c9d820ba5548d431afb4632301acf965db49e666aa21c305cbe8c6de12", size = 78152, upload-time = "2025-10-08T19:47:51.051Z" },
-    { url = "https://files.pythonhosted.org/packages/65/9b/03b04e7d82a5f54fb16113d839f5ea1ede58a61e90edf515f6577c66fa8f/propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c0d4b719b7da33599dfe3b22d3db1ef789210a0597bc650b7cee9c77c2be8c5c", size = 44869, upload-time = "2025-10-08T19:47:52.594Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f302f4783709a78240ebc311b793f123328716a60911d667e0c036bc5dcbded", size = 46596, upload-time = "2025-10-08T19:47:54.073Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c80ee5802e3fb9ea37938e7eecc307fb984837091d5fd262bb37238b1ae97641", size = 206981, upload-time = "2025-10-08T19:47:55.715Z" },
-    { url = "https://files.pythonhosted.org/packages/df/f6/c5fa1357cc9748510ee55f37173eb31bfde6d94e98ccd9e6f033f2fc06e1/propcache-0.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ed5a841e8bb29a55fb8159ed526b26adc5bdd7e8bd7bf793ce647cb08656cdf4", size = 211490, upload-time = "2025-10-08T19:47:57.499Z" },
-    { url = "https://files.pythonhosted.org/packages/80/1e/e5889652a7c4a3846683401a48f0f2e5083ce0ec1a8a5221d8058fbd1adf/propcache-0.4.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:55c72fd6ea2da4c318e74ffdf93c4fe4e926051133657459131a95c846d16d44", size = 215371, upload-time = "2025-10-08T19:47:59.317Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8326e144341460402713f91df60ade3c999d601e7eb5ff8f6f7862d54de0610d", size = 201424, upload-time = "2025-10-08T19:48:00.67Z" },
-    { url = "https://files.pythonhosted.org/packages/27/73/033d63069b57b0812c8bd19f311faebeceb6ba31b8f32b73432d12a0b826/propcache-0.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:060b16ae65bc098da7f6d25bf359f1f31f688384858204fe5d652979e0015e5b", size = 197566, upload-time = "2025-10-08T19:48:02.604Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/89/ce24f3dc182630b4e07aa6d15f0ff4b14ed4b9955fae95a0b54c58d66c05/propcache-0.4.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:89eb3fa9524f7bec9de6e83cf3faed9d79bffa560672c118a96a171a6f55831e", size = 193130, upload-time = "2025-10-08T19:48:04.499Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/24/ef0d5fd1a811fb5c609278d0209c9f10c35f20581fcc16f818da959fc5b4/propcache-0.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dee69d7015dc235f526fe80a9c90d65eb0039103fe565776250881731f06349f", size = 202625, upload-time = "2025-10-08T19:48:06.213Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/02/98ec20ff5546f68d673df2f7a69e8c0d076b5abd05ca882dc7ee3a83653d/propcache-0.4.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5558992a00dfd54ccbc64a32726a3357ec93825a418a401f5cc67df0ac5d9e49", size = 204209, upload-time = "2025-10-08T19:48:08.432Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/87/492694f76759b15f0467a2a93ab68d32859672b646aa8a04ce4864e7932d/propcache-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c9b822a577f560fbd9554812526831712c1436d2c046cedee4c3796d3543b144", size = 197797, upload-time = "2025-10-08T19:48:09.968Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/36/66367de3575db1d2d3f3d177432bd14ee577a39d3f5d1b3d5df8afe3b6e2/propcache-0.4.1-cp314-cp314-win32.whl", hash = "sha256:ab4c29b49d560fe48b696cdcb127dd36e0bc2472548f3bf56cc5cb3da2b2984f", size = 38140, upload-time = "2025-10-08T19:48:11.232Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:5a103c3eb905fcea0ab98be99c3a9a5ab2de60228aa5aceedc614c0281cf6153", size = 41257, upload-time = "2025-10-08T19:48:12.707Z" },
-    { url = "https://files.pythonhosted.org/packages/34/5e/63bd5896c3fec12edcbd6f12508d4890d23c265df28c74b175e1ef9f4f3b/propcache-0.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:74c1fb26515153e482e00177a1ad654721bf9207da8a494a0c05e797ad27b992", size = 38097, upload-time = "2025-10-08T19:48:13.923Z" },
-    { url = "https://files.pythonhosted.org/packages/99/85/9ff785d787ccf9bbb3f3106f79884a130951436f58392000231b4c737c80/propcache-0.4.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:824e908bce90fb2743bd6b59db36eb4f45cd350a39637c9f73b1c1ea66f5b75f", size = 81455, upload-time = "2025-10-08T19:48:15.16Z" },
-    { url = "https://files.pythonhosted.org/packages/90/85/2431c10c8e7ddb1445c1f7c4b54d886e8ad20e3c6307e7218f05922cad67/propcache-0.4.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2b5e7db5328427c57c8e8831abda175421b709672f6cfc3d630c3b7e2146393", size = 46372, upload-time = "2025-10-08T19:48:16.424Z" },
-    { url = "https://files.pythonhosted.org/packages/01/20/b0972d902472da9bcb683fa595099911f4d2e86e5683bcc45de60dd05dc3/propcache-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6f6ff873ed40292cd4969ef5310179afd5db59fdf055897e282485043fc80ad0", size = 48411, upload-time = "2025-10-08T19:48:17.577Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/e3/7dc89f4f21e8f99bad3d5ddb3a3389afcf9da4ac69e3deb2dcdc96e74169/propcache-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49a2dc67c154db2c1463013594c458881a069fcf98940e61a0569016a583020a", size = 275712, upload-time = "2025-10-08T19:48:18.901Z" },
-    { url = "https://files.pythonhosted.org/packages/20/67/89800c8352489b21a8047c773067644e3897f02ecbbd610f4d46b7f08612/propcache-0.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:005f08e6a0529984491e37d8dbc3dd86f84bd78a8ceb5fa9a021f4c48d4984be", size = 273557, upload-time = "2025-10-08T19:48:20.762Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/a1/b52b055c766a54ce6d9c16d9aca0cad8059acd9637cdf8aa0222f4a026ef/propcache-0.4.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c3310452e0d31390da9035c348633b43d7e7feb2e37be252be6da45abd1abcc", size = 280015, upload-time = "2025-10-08T19:48:22.592Z" },
-    { url = "https://files.pythonhosted.org/packages/48/c8/33cee30bd890672c63743049f3c9e4be087e6780906bfc3ec58528be59c1/propcache-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3c70630930447f9ef1caac7728c8ad1c56bc5015338b20fed0d08ea2480b3a", size = 262880, upload-time = "2025-10-08T19:48:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b1/8f08a143b204b418285c88b83d00edbd61afbc2c6415ffafc8905da7038b/propcache-0.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e57061305815dfc910a3634dcf584f08168a8836e6999983569f51a8544cd89", size = 260938, upload-time = "2025-10-08T19:48:25.656Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/12/96e4664c82ca2f31e1c8dff86afb867348979eb78d3cb8546a680287a1e9/propcache-0.4.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:521a463429ef54143092c11a77e04056dd00636f72e8c45b70aaa3140d639726", size = 247641, upload-time = "2025-10-08T19:48:27.207Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ed/e7a9cfca28133386ba52278136d42209d3125db08d0a6395f0cba0c0285c/propcache-0.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:120c964da3fdc75e3731aa392527136d4ad35868cc556fd09bb6d09172d9a367", size = 262510, upload-time = "2025-10-08T19:48:28.65Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/76/16d8bf65e8845dd62b4e2b57444ab81f07f40caa5652b8969b87ddcf2ef6/propcache-0.4.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d8f353eb14ee3441ee844ade4277d560cdd68288838673273b978e3d6d2c8f36", size = 263161, upload-time = "2025-10-08T19:48:30.133Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/70/c99e9edb5d91d5ad8a49fa3c1e8285ba64f1476782fed10ab251ff413ba1/propcache-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ab2943be7c652f09638800905ee1bab2c544e537edb57d527997a24c13dc1455", size = 257393, upload-time = "2025-10-08T19:48:31.567Z" },
-    { url = "https://files.pythonhosted.org/packages/08/02/87b25304249a35c0915d236575bc3574a323f60b47939a2262b77632a3ee/propcache-0.4.1-cp314-cp314t-win32.whl", hash = "sha256:05674a162469f31358c30bcaa8883cb7829fa3110bf9c0991fe27d7896c42d85", size = 42546, upload-time = "2025-10-08T19:48:32.872Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
 ]
 
 [[package]]
@@ -2174,6 +1798,199 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/41/5bf55c3f386b1643812f3a5674edf74b26184378ef0f3e7c7a09a7e2ca7f/scipy-1.16.3-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:81fc5827606858cf71446a5e98715ba0e11f0dbc83d71c7409d05486592a45d6", size = 36659043, upload-time = "2025-10-28T17:32:40.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0f/65582071948cfc45d43e9870bf7ca5f0e0684e165d7c9ef4e50d783073eb/scipy-1.16.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:c97176013d404c7346bf57874eaac5187d969293bf40497140b0a2b2b7482e07", size = 28898986, upload-time = "2025-10-28T17:32:45.325Z" },
+    { url = "https://files.pythonhosted.org/packages/96/5e/36bf3f0ac298187d1ceadde9051177d6a4fe4d507e8f59067dc9dd39e650/scipy-1.16.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2b71d93c8a9936046866acebc915e2af2e292b883ed6e2cbe5c34beb094b82d9", size = 20889814, upload-time = "2025-10-28T17:32:49.277Z" },
+    { url = "https://files.pythonhosted.org/packages/80/35/178d9d0c35394d5d5211bbff7ac4f2986c5488b59506fef9e1de13ea28d3/scipy-1.16.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:3d4a07a8e785d80289dfe66b7c27d8634a773020742ec7187b85ccc4b0e7b686", size = 23565795, upload-time = "2025-10-28T17:32:53.337Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/46/d1146ff536d034d02f83c8afc3c4bab2eddb634624d6529a8512f3afc9da/scipy-1.16.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0553371015692a898e1aa858fed67a3576c34edefa6b7ebdb4e9dde49ce5c203", size = 33349476, upload-time = "2025-10-28T17:32:58.353Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2e/415119c9ab3e62249e18c2b082c07aff907a273741b3f8160414b0e9193c/scipy-1.16.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:72d1717fd3b5e6ec747327ce9bda32d5463f472c9dce9f54499e81fbd50245a1", size = 35676692, upload-time = "2025-10-28T17:33:03.88Z" },
+    { url = "https://files.pythonhosted.org/packages/27/82/df26e44da78bf8d2aeaf7566082260cfa15955a5a6e96e6a29935b64132f/scipy-1.16.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1fb2472e72e24d1530debe6ae078db70fb1605350c88a3d14bc401d6306dbffe", size = 36019345, upload-time = "2025-10-28T17:33:09.773Z" },
+    { url = "https://files.pythonhosted.org/packages/82/31/006cbb4b648ba379a95c87262c2855cd0d09453e500937f78b30f02fa1cd/scipy-1.16.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5192722cffe15f9329a3948c4b1db789fbb1f05c97899187dcf009b283aea70", size = 38678975, upload-time = "2025-10-28T17:33:15.809Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/7f/acbd28c97e990b421af7d6d6cd416358c9c293fc958b8529e0bd5d2a2a19/scipy-1.16.3-cp312-cp312-win_amd64.whl", hash = "sha256:56edc65510d1331dae01ef9b658d428e33ed48b4f77b1d51caf479a0253f96dc", size = 38555926, upload-time = "2025-10-28T17:33:21.388Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/69/c5c7807fd007dad4f48e0a5f2153038dc96e8725d3345b9ee31b2b7bed46/scipy-1.16.3-cp312-cp312-win_arm64.whl", hash = "sha256:a8a26c78ef223d3e30920ef759e25625a0ecdd0d60e5a8818b7513c3e5384cf2", size = 25463014, upload-time = "2025-10-28T17:33:25.975Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f1/57e8327ab1508272029e27eeef34f2302ffc156b69e7e233e906c2a5c379/scipy-1.16.3-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:d2ec56337675e61b312179a1ad124f5f570c00f920cc75e1000025451b88241c", size = 36617856, upload-time = "2025-10-28T17:33:31.375Z" },
+    { url = "https://files.pythonhosted.org/packages/44/13/7e63cfba8a7452eb756306aa2fd9b37a29a323b672b964b4fdeded9a3f21/scipy-1.16.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:16b8bc35a4cc24db80a0ec836a9286d0e31b2503cb2fd7ff7fb0e0374a97081d", size = 28874306, upload-time = "2025-10-28T17:33:36.516Z" },
+    { url = "https://files.pythonhosted.org/packages/15/65/3a9400efd0228a176e6ec3454b1fa998fbbb5a8defa1672c3f65706987db/scipy-1.16.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:5803c5fadd29de0cf27fa08ccbfe7a9e5d741bf63e4ab1085437266f12460ff9", size = 20865371, upload-time = "2025-10-28T17:33:42.094Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/eda09adf009a9fb81827194d4dd02d2e4bc752cef16737cc4ef065234031/scipy-1.16.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:b81c27fc41954319a943d43b20e07c40bdcd3ff7cf013f4fb86286faefe546c4", size = 23524877, upload-time = "2025-10-28T17:33:48.483Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/6b/3f911e1ebc364cb81320223a3422aab7d26c9c7973109a9cd0f27c64c6c0/scipy-1.16.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0c3b4dd3d9b08dbce0f3440032c52e9e2ab9f96ade2d3943313dfe51a7056959", size = 33342103, upload-time = "2025-10-28T17:33:56.495Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f6/4bfb5695d8941e5c570a04d9fcd0d36bce7511b7d78e6e75c8f9791f82d0/scipy-1.16.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7dc1360c06535ea6116a2220f760ae572db9f661aba2d88074fe30ec2aa1ff88", size = 35697297, upload-time = "2025-10-28T17:34:04.722Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6496dadbc80d8d896ff72511ecfe2316b50313bfc3ebf07a3f580f08bd8c/scipy-1.16.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:663b8d66a8748051c3ee9c96465fb417509315b99c71550fda2591d7dd634234", size = 36021756, upload-time = "2025-10-28T17:34:13.482Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/bd/a8c7799e0136b987bda3e1b23d155bcb31aec68a4a472554df5f0937eef7/scipy-1.16.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eab43fae33a0c39006a88096cd7b4f4ef545ea0447d250d5ac18202d40b6611d", size = 38696566, upload-time = "2025-10-28T17:34:22.384Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/01/1204382461fcbfeb05b6161b594f4007e78b6eba9b375382f79153172b4d/scipy-1.16.3-cp313-cp313-win_amd64.whl", hash = "sha256:062246acacbe9f8210de8e751b16fc37458213f124bef161a5a02c7a39284304", size = 38529877, upload-time = "2025-10-28T17:35:51.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/9d9fbcaa1260a94f4bb5b64ba9213ceb5d03cd88841fe9fd1ffd47a45b73/scipy-1.16.3-cp313-cp313-win_arm64.whl", hash = "sha256:50a3dbf286dbc7d84f176f9a1574c705f277cb6565069f88f60db9eafdbe3ee2", size = 25455366, upload-time = "2025-10-28T17:35:59.014Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a3/9ec205bd49f42d45d77f1730dbad9ccf146244c1647605cf834b3a8c4f36/scipy-1.16.3-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:fb4b29f4cf8cc5a8d628bc8d8e26d12d7278cd1f219f22698a378c3d67db5e4b", size = 37027931, upload-time = "2025-10-28T17:34:31.451Z" },
+    { url = "https://files.pythonhosted.org/packages/25/06/ca9fd1f3a4589cbd825b1447e5db3a8ebb969c1eaf22c8579bd286f51b6d/scipy-1.16.3-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:8d09d72dc92742988b0e7750bddb8060b0c7079606c0d24a8cc8e9c9c11f9079", size = 29400081, upload-time = "2025-10-28T17:34:39.087Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/56/933e68210d92657d93fb0e381683bc0e53a965048d7358ff5fbf9e6a1b17/scipy-1.16.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:03192a35e661470197556de24e7cb1330d84b35b94ead65c46ad6f16f6b28f2a", size = 21391244, upload-time = "2025-10-28T17:34:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7e/779845db03dc1418e215726329674b40576879b91814568757ff0014ad65/scipy-1.16.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:57d01cb6f85e34f0946b33caa66e892aae072b64b034183f3d87c4025802a119", size = 23929753, upload-time = "2025-10-28T17:34:51.793Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/f756cf8161d5365dcdef9e5f460ab226c068211030a175d2fc7f3f41ca64/scipy-1.16.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:96491a6a54e995f00a28a3c3badfff58fd093bf26cd5fb34a2188c8c756a3a2c", size = 33496912, upload-time = "2025-10-28T17:34:59.8Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b5/222b1e49a58668f23839ca1542a6322bb095ab8d6590d4f71723869a6c2c/scipy-1.16.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cd13e354df9938598af2be05822c323e97132d5e6306b83a3b4ee6724c6e522e", size = 35802371, upload-time = "2025-10-28T17:35:08.173Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8d/5964ef68bb31829bde27611f8c9deeac13764589fe74a75390242b64ca44/scipy-1.16.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:63d3cdacb8a824a295191a723ee5e4ea7768ca5ca5f2838532d9f2e2b3ce2135", size = 36190477, upload-time = "2025-10-28T17:35:16.7Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f2/b31d75cb9b5fa4dd39a0a931ee9b33e7f6f36f23be5ef560bf72e0f92f32/scipy-1.16.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e7efa2681ea410b10dde31a52b18b0154d66f2485328830e45fdf183af5aefc6", size = 38796678, upload-time = "2025-10-28T17:35:26.354Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1e/b3723d8ff64ab548c38d87055483714fefe6ee20e0189b62352b5e015bb1/scipy-1.16.3-cp313-cp313t-win_amd64.whl", hash = "sha256:2d1ae2cf0c350e7705168ff2429962a89ad90c2d49d1dd300686d8b2a5af22fc", size = 38640178, upload-time = "2025-10-28T17:35:35.304Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f3/d854ff38789aca9b0cc23008d607ced9de4f7ab14fa1ca4329f86b3758ca/scipy-1.16.3-cp313-cp313t-win_arm64.whl", hash = "sha256:0c623a54f7b79dd88ef56da19bc2873afec9673a48f3b85b18e4d402bdd29a5a", size = 25803246, upload-time = "2025-10-28T17:35:42.155Z" },
+    { url = "https://files.pythonhosted.org/packages/99/f6/99b10fd70f2d864c1e29a28bbcaa0c6340f9d8518396542d9ea3b4aaae15/scipy-1.16.3-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:875555ce62743e1d54f06cdf22c1e0bc47b91130ac40fe5d783b6dfa114beeb6", size = 36606469, upload-time = "2025-10-28T17:36:08.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/74/043b54f2319f48ea940dd025779fa28ee360e6b95acb7cd188fad4391c6b/scipy-1.16.3-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:bb61878c18a470021fb515a843dc7a76961a8daceaaaa8bad1332f1bf4b54657", size = 28872043, upload-time = "2025-10-28T17:36:16.599Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e1/24b7e50cc1c4ee6ffbcb1f27fe9f4c8b40e7911675f6d2d20955f41c6348/scipy-1.16.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2622206f5559784fa5c4b53a950c3c7c1cf3e84ca1b9c4b6c03f062f289ca26", size = 20862952, upload-time = "2025-10-28T17:36:22.966Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3a/3e8c01a4d742b730df368e063787c6808597ccb38636ed821d10b39ca51b/scipy-1.16.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7f68154688c515cdb541a31ef8eb66d8cd1050605be9dcd74199cbd22ac739bc", size = 23508512, upload-time = "2025-10-28T17:36:29.731Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/60/c45a12b98ad591536bfe5330cb3cfe1850d7570259303563b1721564d458/scipy-1.16.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3c820ddb80029fe9f43d61b81d8b488d3ef8ca010d15122b152db77dc94c22", size = 33413639, upload-time = "2025-10-28T17:36:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/71/bc/35957d88645476307e4839712642896689df442f3e53b0fa016ecf8a3357/scipy-1.16.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d3837938ae715fc0fe3c39c0202de3a8853aff22ca66781ddc2ade7554b7e2cc", size = 35704729, upload-time = "2025-10-28T17:36:46.547Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/15/89105e659041b1ca11c386e9995aefacd513a78493656e57789f9d9eab61/scipy-1.16.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aadd23f98f9cb069b3bd64ddc900c4d277778242e961751f77a8cb5c4b946fb0", size = 36086251, upload-time = "2025-10-28T17:36:55.161Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/87/c0ea673ac9c6cc50b3da2196d860273bc7389aa69b64efa8493bdd25b093/scipy-1.16.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b7c5f1bda1354d6a19bc6af73a649f8285ca63ac6b52e64e658a5a11d4d69800", size = 38716681, upload-time = "2025-10-28T17:37:04.1Z" },
+    { url = "https://files.pythonhosted.org/packages/91/06/837893227b043fb9b0d13e4bd7586982d8136cb249ffb3492930dab905b8/scipy-1.16.3-cp314-cp314-win_amd64.whl", hash = "sha256:e5d42a9472e7579e473879a1990327830493a7047506d58d73fc429b84c1d49d", size = 39358423, upload-time = "2025-10-28T17:38:20.005Z" },
+    { url = "https://files.pythonhosted.org/packages/95/03/28bce0355e4d34a7c034727505a02d19548549e190bedd13a721e35380b7/scipy-1.16.3-cp314-cp314-win_arm64.whl", hash = "sha256:6020470b9d00245926f2d5bb93b119ca0340f0d564eb6fbaad843eaebf9d690f", size = 26135027, upload-time = "2025-10-28T17:38:24.966Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6f/69f1e2b682efe9de8fe9f91040f0cd32f13cfccba690512ba4c582b0bc29/scipy-1.16.3-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:e1d27cbcb4602680a49d787d90664fa4974063ac9d4134813332a8c53dbe667c", size = 37028379, upload-time = "2025-10-28T17:37:14.061Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2d/e826f31624a5ebbab1cd93d30fd74349914753076ed0593e1d56a98c4fb4/scipy-1.16.3-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:9b9c9c07b6d56a35777a1b4cc8966118fb16cfd8daf6743867d17d36cfad2d40", size = 29400052, upload-time = "2025-10-28T17:37:21.709Z" },
+    { url = "https://files.pythonhosted.org/packages/69/27/d24feb80155f41fd1f156bf144e7e049b4e2b9dd06261a242905e3bc7a03/scipy-1.16.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:3a4c460301fb2cffb7f88528f30b3127742cff583603aa7dc964a52c463b385d", size = 21391183, upload-time = "2025-10-28T17:37:29.559Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d3/1b229e433074c5738a24277eca520a2319aac7465eea7310ea6ae0e98ae2/scipy-1.16.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:f667a4542cc8917af1db06366d3f78a5c8e83badd56409f94d1eac8d8d9133fa", size = 23930174, upload-time = "2025-10-28T17:37:36.306Z" },
+    { url = "https://files.pythonhosted.org/packages/16/9d/d9e148b0ec680c0f042581a2be79a28a7ab66c0c4946697f9e7553ead337/scipy-1.16.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f379b54b77a597aa7ee5e697df0d66903e41b9c85a6dd7946159e356319158e8", size = 33497852, upload-time = "2025-10-28T17:37:42.228Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/22/4e5f7561e4f98b7bea63cf3fd7934bff1e3182e9f1626b089a679914d5c8/scipy-1.16.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4aff59800a3b7f786b70bfd6ab551001cb553244988d7d6b8299cb1ea653b353", size = 35798595, upload-time = "2025-10-28T17:37:48.102Z" },
+    { url = "https://files.pythonhosted.org/packages/83/42/6644d714c179429fc7196857866f219fef25238319b650bb32dde7bf7a48/scipy-1.16.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:da7763f55885045036fabcebd80144b757d3db06ab0861415d1c3b7c69042146", size = 36186269, upload-time = "2025-10-28T17:37:53.72Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/70/64b4d7ca92f9cf2e6fc6aaa2eecf80bb9b6b985043a9583f32f8177ea122/scipy-1.16.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ffa6eea95283b2b8079b821dc11f50a17d0571c92b43e2b5b12764dc5f9b285d", size = 38802779, upload-time = "2025-10-28T17:37:59.393Z" },
+    { url = "https://files.pythonhosted.org/packages/61/82/8d0e39f62764cce5ffd5284131e109f07cf8955aef9ab8ed4e3aa5e30539/scipy-1.16.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d9f48cafc7ce94cf9b15c6bffdc443a81a27bf7075cf2dcd5c8b40f85d10c4e7", size = 39471128, upload-time = "2025-10-28T17:38:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/64/47/a494741db7280eae6dc033510c319e34d42dd41b7ac0c7ead39354d1a2b5/scipy-1.16.3-cp314-cp314t-win_arm64.whl", hash = "sha256:21d9d6b197227a12dcbf9633320a4e34c6b0e51c57268df255a0942983bac562", size = 26464127, upload-time = "2025-10-28T17:38:11.34Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/a1/64e7b111e753307ffb7c5b6d039c52d4a91a47fa32a7f5bc377a49b22402/sentence_transformers-5.2.0.tar.gz", hash = "sha256:acaeb38717de689f3dab45d5e5a02ebe2f75960a4764ea35fea65f58a4d3019f", size = 381004, upload-time = "2025-12-11T14:12:31.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/d0/3b2897ef6a0c0c801e9fecca26bcc77081648e38e8c772885ebdd8d7d252/sentence_transformers-5.2.0-py3-none-any.whl", hash = "sha256:aa57180f053687d29b08206766ae7db549be5074f61849def7b17bf0b8025ca2", size = 493748, upload-time = "2025-12-11T14:12:29.516Z" },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/15/2e7a025fc62d764b151ae6d0f2a92f8081755ebe8d4a64099accc6f77ba6/sentencepiece-0.2.1.tar.gz", hash = "sha256:8138cec27c2f2282f4a34d9a016e3374cd40e5c6e9cb335063db66a0a3b71fad", size = 3228515, upload-time = "2025-08-12T07:00:51.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/be/32ce495aa1d0e0c323dcb1ba87096037358edee539cac5baf8755a6bd396/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57cae326c8727de58c85977b175af132a7138d84c764635d7e71bbee7e774133", size = 1943152, upload-time = "2025-08-12T06:59:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7e/ff23008899a58678e98c6ff592bf4d368eee5a71af96d0df6b38a039dd4f/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:56dd39a3c4d6493db3cdca7e8cc68c6b633f0d4195495cbadfcf5af8a22d05a6", size = 1325651, upload-time = "2025-08-12T06:59:41.536Z" },
+    { url = "https://files.pythonhosted.org/packages/19/84/42eb3ce4796777a1b5d3699dfd4dca85113e68b637f194a6c8d786f16a04/sentencepiece-0.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d9381351182ff9888cc80e41c632e7e274b106f450de33d67a9e8f6043da6f76", size = 1253645, upload-time = "2025-08-12T06:59:42.903Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fa/d3d5ebcba3cb9e6d3775a096251860c41a6bc53a1b9461151df83fe93255/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99f955df238021bf11f0fc37cdb54fd5e5b5f7fd30ecc3d93fb48b6815437167", size = 1316273, upload-time = "2025-08-12T06:59:44.476Z" },
+    { url = "https://files.pythonhosted.org/packages/04/88/14f2f4a2b922d8b39be45bf63d79e6cd3a9b2f248b2fcb98a69b12af12f5/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cdfecef430d985f1c2bcbfff3defd1d95dae876fbd0173376012d2d7d24044b", size = 1387881, upload-time = "2025-08-12T06:59:46.09Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/b8/903e5ccb77b4ef140605d5d71b4f9e0ad95d456d6184688073ed11712809/sentencepiece-0.2.1-cp312-cp312-win32.whl", hash = "sha256:a483fd29a34c3e34c39ac5556b0a90942bec253d260235729e50976f5dba1068", size = 999540, upload-time = "2025-08-12T06:59:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/81/92df5673c067148c2545b1bfe49adfd775bcc3a169a047f5a0e6575ddaca/sentencepiece-0.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:4cdc7c36234fda305e85c32949c5211faaf8dd886096c7cea289ddc12a2d02de", size = 1054671, upload-time = "2025-08-12T06:59:49.895Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/02/c5e3bc518655d714622bec87d83db9cdba1cd0619a4a04e2109751c4f47f/sentencepiece-0.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:daeb5e9e9fcad012324807856113708614d534f596d5008638eb9b40112cd9e4", size = 1033923, upload-time = "2025-08-12T06:59:51.952Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4a/85fbe1706d4d04a7e826b53f327c4b80f849cf1c7b7c5e31a20a97d8f28b/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dcd8161eee7b41aae57ded06272905dbd680a0a04b91edd0f64790c796b2f706", size = 1943150, upload-time = "2025-08-12T06:59:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/4cfb393e287509fc2155480b9d184706ef8d9fa8cbf5505d02a5792bf220/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c6c8f42949f419ff8c7e9960dbadcfbc982d7b5efc2f6748210d3dd53a7de062", size = 1325651, upload-time = "2025-08-12T06:59:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/de/5a007fb53b1ab0aafc69d11a5a3dd72a289d5a3e78dcf2c3a3d9b14ffe93/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:097f3394e99456e9e4efba1737c3749d7e23563dd1588ce71a3d007f25475fff", size = 1253641, upload-time = "2025-08-12T06:59:56.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d2/f552be5928105588f4f4d66ee37dd4c61460d8097e62d0e2e0eec41bc61d/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b670879c370d350557edabadbad1f6561a9e6968126e6debca4029e5547820", size = 1316271, upload-time = "2025-08-12T06:59:58.109Z" },
+    { url = "https://files.pythonhosted.org/packages/96/df/0cfe748ace5485be740fed9476dee7877f109da32ed0d280312c94ec259f/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7f0fd2f2693309e6628aeeb2e2faf6edd221134dfccac3308ca0de01f8dab47", size = 1387882, upload-time = "2025-08-12T07:00:00.701Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dd/f7774d42a881ced8e1739f393ab1e82ece39fc9abd4779e28050c2e975b5/sentencepiece-0.2.1-cp313-cp313-win32.whl", hash = "sha256:92b3816aa2339355fda2c8c4e021a5de92180b00aaccaf5e2808972e77a4b22f", size = 999541, upload-time = "2025-08-12T07:00:02.709Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e9/932b9eae6fd7019548321eee1ab8d5e3b3d1294df9d9a0c9ac517c7b636d/sentencepiece-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:10ed3dab2044c47f7a2e7b4969b0c430420cdd45735d78c8f853191fa0e3148b", size = 1054669, upload-time = "2025-08-12T07:00:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3a/76488a00ea7d6931689cda28726a1447d66bf1a4837943489314593d5596/sentencepiece-0.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac650534e2251083c5f75dde4ff28896ce7c8904133dc8fef42780f4d5588fcd", size = 1033922, upload-time = "2025-08-12T07:00:06.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b6/08fe2ce819e02ccb0296f4843e3f195764ce9829cbda61b7513f29b95718/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dd4b477a7b069648d19363aad0cab9bad2f4e83b2d179be668efa672500dc94", size = 1946052, upload-time = "2025-08-12T07:00:08.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d9/1ea0e740591ff4c6fc2b6eb1d7510d02f3fb885093f19b2f3abd1363b402/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0c0f672da370cc490e4c59d89e12289778310a0e71d176c541e4834759e1ae07", size = 1327408, upload-time = "2025-08-12T07:00:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/1fb26e8a21613f6200e1ab88824d5d203714162cf2883248b517deb500b7/sentencepiece-0.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ad8493bea8432dae8d6830365352350f3b4144415a1d09c4c8cb8d30cf3b6c3c", size = 1254857, upload-time = "2025-08-12T07:00:11.021Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/85/c72fd1f3c7a6010544d6ae07f8ddb38b5e2a7e33bd4318f87266c0bbafbf/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b81a24733726e3678d2db63619acc5a8dccd074f7aa7a54ecd5ca33ca6d2d596", size = 1315722, upload-time = "2025-08-12T07:00:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e8/661e5bd82a8aa641fd6c1020bd0e890ef73230a2b7215ddf9c8cd8e941c2/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a81799d0a68d618e89063fb423c3001a034c893069135ffe51fee439ae474d6", size = 1387452, upload-time = "2025-08-12T07:00:15.088Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5e/ae66c361023a470afcbc1fbb8da722c72ea678a2fcd9a18f1a12598c7501/sentencepiece-0.2.1-cp313-cp313t-win32.whl", hash = "sha256:89a3ea015517c42c0341d0d962f3e6aaf2cf10d71b1932d475c44ba48d00aa2b", size = 1002501, upload-time = "2025-08-12T07:00:16.966Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/03/d332828c4ff764e16c1b56c2c8f9a33488bbe796b53fb6b9c4205ddbf167/sentencepiece-0.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:33f068c9382dc2e7c228eedfd8163b52baa86bb92f50d0488bf2b7da7032e484", size = 1057555, upload-time = "2025-08-12T07:00:18.573Z" },
+    { url = "https://files.pythonhosted.org/packages/88/14/5aee0bf0864df9bd82bd59e7711362908e4935e3f9cdc1f57246b5d5c9b9/sentencepiece-0.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:b3616ad246f360e52c85781e47682d31abfb6554c779e42b65333d4b5f44ecc0", size = 1036042, upload-time = "2025-08-12T07:00:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9c/89eb8b2052f720a612478baf11c8227dcf1dc28cd4ea4c0c19506b5af2a2/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:5d0350b686c320068702116276cfb26c066dc7e65cfef173980b11bb4d606719", size = 1943147, upload-time = "2025-08-12T07:00:21.809Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0b/a1432bc87f97c2ace36386ca23e8bd3b91fb40581b5e6148d24b24186419/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c7f54a31cde6fa5cb030370566f68152a742f433f8d2be458463d06c208aef33", size = 1325624, upload-time = "2025-08-12T07:00:23.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/99/bbe054ebb5a5039457c590e0a4156ed073fb0fe9ce4f7523404dd5b37463/sentencepiece-0.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c83b85ab2d6576607f31df77ff86f28182be4a8de6d175d2c33ca609925f5da1", size = 1253670, upload-time = "2025-08-12T07:00:24.69Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ad/d5c7075f701bd97971d7c2ac2904f227566f51ef0838dfbdfdccb58cd212/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1855f57db07b51fb51ed6c9c452f570624d2b169b36f0f79ef71a6e6c618cd8b", size = 1316247, upload-time = "2025-08-12T07:00:26.435Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/03/35fbe5f3d9a7435eebd0b473e09584bd3cc354ce118b960445b060d33781/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01e6912125cb45d3792f530a4d38f8e21bf884d6b4d4ade1b2de5cf7a8d2a52b", size = 1387894, upload-time = "2025-08-12T07:00:28.339Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/aa/956ef729aafb6c8f9c443104c9636489093bb5c61d6b90fc27aa1a865574/sentencepiece-0.2.1-cp314-cp314-win32.whl", hash = "sha256:c415c9de1447e0a74ae3fdb2e52f967cb544113a3a5ce3a194df185cbc1f962f", size = 1096698, upload-time = "2025-08-12T07:00:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/fe400d8836952cc535c81a0ce47dc6875160e5fedb71d2d9ff0e9894c2a6/sentencepiece-0.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:881b2e44b14fc19feade3cbed314be37de639fc415375cefaa5bc81a4be137fd", size = 1155115, upload-time = "2025-08-12T07:00:32.865Z" },
+    { url = "https://files.pythonhosted.org/packages/32/89/047921cf70f36c7b6b6390876b2399b3633ab73b8d0cb857e5a964238941/sentencepiece-0.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:2005242a16d2dc3ac5fe18aa7667549134d37854823df4c4db244752453b78a8", size = 1133890, upload-time = "2025-08-12T07:00:34.763Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/11/5b414b9fae6255b5fb1e22e2ed3dc3a72d3a694e5703910e640ac78346bb/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a19adcec27c524cb7069a1c741060add95f942d1cbf7ad0d104dffa0a7d28a2b", size = 1946081, upload-time = "2025-08-12T07:00:36.97Z" },
+    { url = "https://files.pythonhosted.org/packages/77/eb/7a5682bb25824db8545f8e5662e7f3e32d72a508fdce086029d89695106b/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:e37e4b4c4a11662b5db521def4e44d4d30ae69a1743241412a93ae40fdcab4bb", size = 1327406, upload-time = "2025-08-12T07:00:38.669Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b0/811dae8fb9f2784e138785d481469788f2e0d0c109c5737372454415f55f/sentencepiece-0.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:477c81505db072b3ab627e7eab972ea1025331bd3a92bacbf798df2b75ea86ec", size = 1254846, upload-time = "2025-08-12T07:00:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/23/195b2e7ec85ebb6a547969f60b723c7aca5a75800ece6cc3f41da872d14e/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:010f025a544ef770bb395091d57cb94deb9652d8972e0d09f71d85d5a0816c8c", size = 1315721, upload-time = "2025-08-12T07:00:42.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/aa/553dbe4178b5f23eb28e59393dddd64186178b56b81d9b8d5c3ff1c28395/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:733e59ff1794d26db706cd41fc2d7ca5f6c64a820709cb801dc0ea31780d64ab", size = 1387458, upload-time = "2025-08-12T07:00:44.56Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7c/08ff0012507297a4dd74a5420fdc0eb9e3e80f4e88cab1538d7f28db303d/sentencepiece-0.2.1-cp314-cp314t-win32.whl", hash = "sha256:d3233770f78e637dc8b1fda2cd7c3b99ec77e7505041934188a4e7fe751de3b0", size = 1099765, upload-time = "2025-08-12T07:00:46.058Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d5/2a69e1ce15881beb9ddfc7e3f998322f5cedcd5e4d244cb74dade9441663/sentencepiece-0.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e4366c97b68218fd30ea72d70c525e6e78a6c0a88650f57ac4c43c63b234a9d", size = 1157807, upload-time = "2025-08-12T07:00:47.673Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/16/54f611fcfc2d1c46cbe3ec4169780b2cfa7cf63708ef2b71611136db7513/sentencepiece-0.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:105e36e75cbac1292642045458e8da677b2342dcd33df503e640f0b457cb6751", size = 1136264, upload-time = "2025-08-12T07:00:49.485Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2270,6 +2087,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2279,50 +2108,12 @@ wheels = [
 ]
 
 [[package]]
-name = "tiktoken"
-version = "0.12.0"
+name = "threadpoolctl"
+version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "regex" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
-    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
-    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
-    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
-    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
-    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
-    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
-    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
-    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
-    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
-    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
-    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
-    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
-    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
-    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -2360,6 +2151,58 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/27/07c645c7673e73e53ded71705045d6cb5bae94c4b021b03aa8d03eee90ab/torch-2.9.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da5f6f4d7f4940a173e5572791af238cb0b9e21b1aab592bd8b26da4c99f1cd6", size = 104126592, upload-time = "2025-11-12T15:20:41.62Z" },
+    { url = "https://files.pythonhosted.org/packages/19/17/e377a460603132b00760511299fceba4102bd95db1a0ee788da21298ccff/torch-2.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:27331cd902fb4322252657f3902adf1c4f6acad9dcad81d8df3ae14c7c4f07c4", size = 899742281, upload-time = "2025-11-12T15:22:17.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1a/64f5769025db846a82567fa5b7d21dba4558a7234ee631712ee4771c436c/torch-2.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:81a285002d7b8cfd3fdf1b98aa8df138d41f1a8334fd9ea37511517cedf43083", size = 110940568, upload-time = "2025-11-12T15:21:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ab/07739fd776618e5882661d04c43f5b5586323e2f6a2d7d84aac20d8f20bd/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:c0d25d1d8e531b8343bea0ed811d5d528958f1dcbd37e7245bc686273177ad7e", size = 74479191, upload-time = "2025-11-12T15:21:25.816Z" },
+    { url = "https://files.pythonhosted.org/packages/20/60/8fc5e828d050bddfab469b3fe78e5ab9a7e53dda9c3bdc6a43d17ce99e63/torch-2.9.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c29455d2b910b98738131990394da3e50eea8291dfeb4b12de71ecf1fdeb21cb", size = 104135743, upload-time = "2025-11-12T15:21:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/6d3f80e6918213babddb2a37b46dbb14c15b14c5f473e347869a51f40e1f/torch-2.9.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:524de44cd13931208ba2c4bde9ec7741fd4ae6bfd06409a604fc32f6520c2bc9", size = 899749493, upload-time = "2025-11-12T15:24:36.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/47/c7843d69d6de8938c1cbb1eba426b1d48ddf375f101473d3e31a5fc52b74/torch-2.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:545844cc16b3f91e08ce3b40e9c2d77012dd33a48d505aed34b7740ed627a1b2", size = 110944162, upload-time = "2025-11-12T15:21:53.151Z" },
+    { url = "https://files.pythonhosted.org/packages/28/0e/2a37247957e72c12151b33a01e4df651d9d155dd74d8cfcbfad15a79b44a/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5be4bf7496f1e3ffb1dd44b672adb1ac3f081f204c5ca81eba6442f5f634df8e", size = 74830751, upload-time = "2025-11-12T15:21:43.792Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/7a18745edcd7b9ca2381aa03353647bca8aace91683c4975f19ac233809d/torch-2.9.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:30a3e170a84894f3652434b56d59a64a2c11366b0ed5776fab33c2439396bf9a", size = 104142929, upload-time = "2025-11-12T15:21:48.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/dd/f1c0d879f2863ef209e18823a988dc7a1bf40470750e3ebe927efdb9407f/torch-2.9.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8301a7b431e51764629208d0edaa4f9e4c33e6df0f2f90b90e261d623df6a4e2", size = 899748978, upload-time = "2025-11-12T15:23:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/9f/6986b83a53b4d043e36f3f898b798ab51f7f20fdf1a9b01a2720f445043d/torch-2.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2e1c42c0ae92bf803a4b2409fdfed85e30f9027a66887f5e7dcdbc014c7531db", size = 111176995, upload-time = "2025-11-12T15:22:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/40/60/71c698b466dd01e65d0e9514b5405faae200c52a76901baf6906856f17e4/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:2c14b3da5df416cf9cb5efab83aa3056f5b8cd8620b8fde81b4987ecab730587", size = 74480347, upload-time = "2025-11-12T15:21:57.648Z" },
+    { url = "https://files.pythonhosted.org/packages/48/50/c4b5112546d0d13cc9eaa1c732b823d676a9f49ae8b6f97772f795874a03/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1edee27a7c9897f4e0b7c14cfc2f3008c571921134522d5b9b5ec4ebbc69041a", size = 74433245, upload-time = "2025-11-12T15:22:39.027Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c9/2628f408f0518b3bae49c95f5af3728b6ab498c8624ab1e03a43dd53d650/torch-2.9.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:19d144d6b3e29921f1fc70503e9f2fc572cde6a5115c0c0de2f7ca8b1483e8b6", size = 104134804, upload-time = "2025-11-12T15:22:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/5bc91d6d831ae41bf6e9e6da6468f25330522e92347c9156eb3f1cb95956/torch-2.9.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c432d04376f6d9767a9852ea0def7b47a7bbc8e7af3b16ac9cf9ce02b12851c9", size = 899747132, upload-time = "2025-11-12T15:23:36.068Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/e8d4e009e52b6b2cf1684bde2a6be157b96fb873732542fb2a9a99e85a83/torch-2.9.1-cp314-cp314-win_amd64.whl", hash = "sha256:d187566a2cdc726fc80138c3cdb260970fab1c27e99f85452721f7759bbd554d", size = 110934845, upload-time = "2025-11-12T15:22:48.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b2/2d15a52516b2ea3f414643b8de68fa4cb220d3877ac8b1028c83dc8ca1c4/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb10896a1f7fedaddbccc2017ce6ca9ecaaf990f0973bdfcf405439750118d2c", size = 74823558, upload-time = "2025-11-12T15:22:43.392Z" },
+    { url = "https://files.pythonhosted.org/packages/86/5c/5b2e5d84f5b9850cd1e71af07524d8cbb74cba19379800f1f9f7c997fc70/torch-2.9.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0a2bd769944991c74acf0c4ef23603b9c777fdf7637f115605a4b2d8023110c7", size = 104145788, upload-time = "2025-11-12T15:23:52.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8c/3da60787bcf70add986c4ad485993026ac0ca74f2fc21410bc4eb1bb7695/torch-2.9.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:07c8a9660bc9414c39cac530ac83b1fb1b679d7155824144a40a54f4a47bfa73", size = 899735500, upload-time = "2025-11-12T15:24:08.788Z" },
+    { url = "https://files.pythonhosted.org/packages/db/2b/f7818f6ec88758dfd21da46b6cd46af9d1b3433e53ddbb19ad1e0da17f9b/torch-2.9.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c88d3299ddeb2b35dcc31753305612db485ab6f1823e37fb29451c8b2732b87e", size = 111163659, upload-time = "2025-11-12T15:23:20.009Z" },
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2391,6 +2234,39 @@ wheels = [
 ]
 
 [[package]]
+name = "transformers"
+version = "4.57.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/70/d42a739e8dfde3d92bb2fff5819cbf331fe9657323221e79415cd5eb65ee/transformers-4.57.3.tar.gz", hash = "sha256:df4945029aaddd7c09eec5cad851f30662f8bd1746721b34cc031d70c65afebc", size = 10139680, upload-time = "2025-11-25T15:51:30.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6b/2f416568b3c4c91c96e5a365d164f8a4a4a88030aa8ab4644181fdadce97/transformers-4.57.3-py3-none-any.whl", hash = "sha256:c77d353a4851b1880191603d36acb313411d3577f6e2897814f333841f7003f4", size = 11993463, upload-time = "2025-11-25T15:51:26.493Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
+    { url = "https://files.pythonhosted.org/packages/27/46/8c3bbb5b0a19313f50edcaa363b599e5a1a5ac9683ead82b9b80fe497c8d/triton-3.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3f4346b6ebbd4fad18773f5ba839114f4826037c9f2f34e0148894cd5dd3dba", size = 170470410, upload-time = "2025-11-11T17:41:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e6/c595c35e5c50c4bc56a7bac96493dad321e9e29b953b526bbbe20f9911d0/triton-3.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0637b1efb1db599a8e9dc960d53ab6e4637db7d4ab6630a0974705d77b14b60", size = 170480488, upload-time = "2025-11-11T17:41:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b5/b0d3d8b901b6a04ca38df5e24c27e53afb15b93624d7fd7d658c7cd9352a/triton-3.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bac7f7d959ad0f48c0e97d6643a1cc0fd5786fe61cb1f83b537c6b2d54776478", size = 170582192, upload-time = "2025-11-11T17:41:23.963Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2403,19 +2279,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/28/7c85c8032b91dbe79725b6f17d2fffc595dff06a35c7a30a37bef73a1ab4/typer-0.20.0.tar.gz", hash = "sha256:1aaf6494031793e4876fb0bacfa6a912b551cf43c1e63c800df8b1a866720c37", size = 106492, upload-time = "2025-10-20T17:03:49.445Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/64/7713ffe4b5983314e9d436a90d5bd4f63b6054e2aca783a3cfc44cb95bbf/typer-0.20.0-py3-none-any.whl", hash = "sha256:5b463df6793ec1dca6213a3cf4c0f03bc6e322ac5e16e13ddd622a889489784a", size = 47028, upload-time = "2025-10-20T17:03:47.617Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/45/81b94a52caed434b94da65729c03ad0fb7665fab0f7db9ee54c94e541403/typer_slim-0.20.0.tar.gz", hash = "sha256:9fc6607b3c6c20f5c33ea9590cbeb17848667c51feee27d9e314a579ab07d1a3", size = 106561, upload-time = "2025-10-20T17:03:46.642Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/dd/5cbf31f402f1cc0ab087c94d4669cfa55bd1e818688b910631e131d74e75/typer_slim-0.20.0-py3-none-any.whl", hash = "sha256:f42a9b7571a12b97dddf364745d29f12221865acef7a2680065f9bb29c7dc89d", size = 47087, upload-time = "2025-10-20T17:03:44.546Z" },
 ]
 
 [[package]]
@@ -2525,107 +2388,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/f2/cd8b7584a48ee83f0bc94f8a32fea38734cefcdc6f7324c4d3bfc699457b/yamllint-1.37.1.tar.gz", hash = "sha256:81f7c0c5559becc8049470d86046b36e96113637bcbe4753ecef06977c00245d", size = 141613, upload-time = "2025-05-04T08:25:54.355Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/b9/be7a4cfdf47e03785f657f94daea8123e838d817be76c684298305bd789f/yamllint-1.37.1-py3-none-any.whl", hash = "sha256:364f0d79e81409f591e323725e6a9f4504c8699ddf2d7263d8d2b539cd66a583", size = 68813, upload-time = "2025-05-04T08:25:52.552Z" },
-]
-
-[[package]]
-name = "yarl"
-version = "1.22.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71", size = 187169, upload-time = "2025-10-06T14:12:55.963Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/ff/46736024fee3429b80a165a732e38e5d5a238721e634ab41b040d49f8738/yarl-1.22.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e340382d1afa5d32b892b3ff062436d592ec3d692aeea3bef3a5cfe11bbf8c6f", size = 142000, upload-time = "2025-10-06T14:09:44.631Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/9a/b312ed670df903145598914770eb12de1bac44599549b3360acc96878df8/yarl-1.22.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f1e09112a2c31ffe8d80be1b0988fa6a18c5d5cad92a9ffbb1c04c91bfe52ad2", size = 94338, upload-time = "2025-10-06T14:09:46.372Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/f5/0601483296f09c3c65e303d60c070a5c19fcdbc72daa061e96170785bc7d/yarl-1.22.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:939fe60db294c786f6b7c2d2e121576628468f65453d86b0fe36cb52f987bd74", size = 94909, upload-time = "2025-10-06T14:09:48.648Z" },
-    { url = "https://files.pythonhosted.org/packages/60/41/9a1fe0b73dbcefce72e46cf149b0e0a67612d60bfc90fb59c2b2efdfbd86/yarl-1.22.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e1651bf8e0398574646744c1885a41198eba53dc8a9312b954073f845c90a8df", size = 372940, upload-time = "2025-10-06T14:09:50.089Z" },
-    { url = "https://files.pythonhosted.org/packages/17/7a/795cb6dfee561961c30b800f0ed616b923a2ec6258b5def2a00bf8231334/yarl-1.22.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b8a0588521a26bf92a57a1705b77b8b59044cdceccac7151bd8d229e66b8dedb", size = 345825, upload-time = "2025-10-06T14:09:52.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/93/a58f4d596d2be2ae7bab1a5846c4d270b894958845753b2c606d666744d3/yarl-1.22.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42188e6a615c1a75bcaa6e150c3fe8f3e8680471a6b10150c5f7e83f47cc34d2", size = 386705, upload-time = "2025-10-06T14:09:54.128Z" },
-    { url = "https://files.pythonhosted.org/packages/61/92/682279d0e099d0e14d7fd2e176bd04f48de1484f56546a3e1313cd6c8e7c/yarl-1.22.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6d2cb59377d99718913ad9a151030d6f83ef420a2b8f521d94609ecc106ee82", size = 396518, upload-time = "2025-10-06T14:09:55.762Z" },
-    { url = "https://files.pythonhosted.org/packages/db/0f/0d52c98b8a885aeda831224b78f3be7ec2e1aa4a62091f9f9188c3c65b56/yarl-1.22.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50678a3b71c751d58d7908edc96d332af328839eea883bb554a43f539101277a", size = 377267, upload-time = "2025-10-06T14:09:57.958Z" },
-    { url = "https://files.pythonhosted.org/packages/22/42/d2685e35908cbeaa6532c1fc73e89e7f2efb5d8a7df3959ea8e37177c5a3/yarl-1.22.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1e8fbaa7cec507aa24ea27a01456e8dd4b6fab829059b69844bd348f2d467124", size = 365797, upload-time = "2025-10-06T14:09:59.527Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/83/cf8c7bcc6355631762f7d8bdab920ad09b82efa6b722999dfb05afa6cfac/yarl-1.22.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:433885ab5431bc3d3d4f2f9bd15bfa1614c522b0f1405d62c4f926ccd69d04fa", size = 365535, upload-time = "2025-10-06T14:10:01.139Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e1/5302ff9b28f0c59cac913b91fe3f16c59a033887e57ce9ca5d41a3a94737/yarl-1.22.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b790b39c7e9a4192dc2e201a282109ed2985a1ddbd5ac08dc56d0e121400a8f7", size = 382324, upload-time = "2025-10-06T14:10:02.756Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/cd/4617eb60f032f19ae3a688dc990d8f0d89ee0ea378b61cac81ede3e52fae/yarl-1.22.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31f0b53913220599446872d757257be5898019c85e7971599065bc55065dc99d", size = 383803, upload-time = "2025-10-06T14:10:04.552Z" },
-    { url = "https://files.pythonhosted.org/packages/59/65/afc6e62bb506a319ea67b694551dab4a7e6fb7bf604e9bd9f3e11d575fec/yarl-1.22.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a49370e8f711daec68d09b821a34e1167792ee2d24d405cbc2387be4f158b520", size = 374220, upload-time = "2025-10-06T14:10:06.489Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3d/68bf18d50dc674b942daec86a9ba922d3113d8399b0e52b9897530442da2/yarl-1.22.0-cp312-cp312-win32.whl", hash = "sha256:70dfd4f241c04bd9239d53b17f11e6ab672b9f1420364af63e8531198e3f5fe8", size = 81589, upload-time = "2025-10-06T14:10:09.254Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/9a/6ad1a9b37c2f72874f93e691b2e7ecb6137fb2b899983125db4204e47575/yarl-1.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:8884d8b332a5e9b88e23f60bb166890009429391864c685e17bd73a9eda9105c", size = 87213, upload-time = "2025-10-06T14:10:11.369Z" },
-    { url = "https://files.pythonhosted.org/packages/44/c5/c21b562d1680a77634d748e30c653c3ca918beb35555cff24986fff54598/yarl-1.22.0-cp312-cp312-win_arm64.whl", hash = "sha256:ea70f61a47f3cc93bdf8b2f368ed359ef02a01ca6393916bc8ff877427181e74", size = 81330, upload-time = "2025-10-06T14:10:13.112Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f3/d67de7260456ee105dc1d162d43a019ecad6b91e2f51809d6cddaa56690e/yarl-1.22.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8dee9c25c74997f6a750cd317b8ca63545169c098faee42c84aa5e506c819b53", size = 139980, upload-time = "2025-10-06T14:10:14.601Z" },
-    { url = "https://files.pythonhosted.org/packages/01/88/04d98af0b47e0ef42597b9b28863b9060bb515524da0a65d5f4db160b2d5/yarl-1.22.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:01e73b85a5434f89fc4fe27dcda2aff08ddf35e4d47bbbea3bdcd25321af538a", size = 93424, upload-time = "2025-10-06T14:10:16.115Z" },
-    { url = "https://files.pythonhosted.org/packages/18/91/3274b215fd8442a03975ce6bee5fe6aa57a8326b29b9d3d56234a1dca244/yarl-1.22.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:22965c2af250d20c873cdbee8ff958fb809940aeb2e74ba5f20aaf6b7ac8c70c", size = 93821, upload-time = "2025-10-06T14:10:17.993Z" },
-    { url = "https://files.pythonhosted.org/packages/61/3a/caf4e25036db0f2da4ca22a353dfeb3c9d3c95d2761ebe9b14df8fc16eb0/yarl-1.22.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4f15793aa49793ec8d1c708ab7f9eded1aa72edc5174cae703651555ed1b601", size = 373243, upload-time = "2025-10-06T14:10:19.44Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/9e/51a77ac7516e8e7803b06e01f74e78649c24ee1021eca3d6a739cb6ea49c/yarl-1.22.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5542339dcf2747135c5c85f68680353d5cb9ffd741c0f2e8d832d054d41f35a", size = 342361, upload-time = "2025-10-06T14:10:21.124Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/f8/33b92454789dde8407f156c00303e9a891f1f51a0330b0fad7c909f87692/yarl-1.22.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5c401e05ad47a75869c3ab3e35137f8468b846770587e70d71e11de797d113df", size = 387036, upload-time = "2025-10-06T14:10:22.902Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/9a/c5db84ea024f76838220280f732970aa4ee154015d7f5c1bfb60a267af6f/yarl-1.22.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:243dda95d901c733f5b59214d28b0120893d91777cb8aa043e6ef059d3cddfe2", size = 397671, upload-time = "2025-10-06T14:10:24.523Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c9/cd8538dc2e7727095e0c1d867bad1e40c98f37763e6d995c1939f5fdc7b1/yarl-1.22.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bec03d0d388060058f5d291a813f21c011041938a441c593374da6077fe21b1b", size = 377059, upload-time = "2025-10-06T14:10:26.406Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/b9/ab437b261702ced75122ed78a876a6dec0a1b0f5e17a4ac7a9a2482d8abe/yarl-1.22.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0748275abb8c1e1e09301ee3cf90c8a99678a4e92e4373705f2a2570d581273", size = 365356, upload-time = "2025-10-06T14:10:28.461Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/9d/8e1ae6d1d008a9567877b08f0ce4077a29974c04c062dabdb923ed98e6fe/yarl-1.22.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:47fdb18187e2a4e18fda2c25c05d8251a9e4a521edaed757fef033e7d8498d9a", size = 361331, upload-time = "2025-10-06T14:10:30.541Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/5a/09b7be3905962f145b73beb468cdd53db8aa171cf18c80400a54c5b82846/yarl-1.22.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c7044802eec4524fde550afc28edda0dd5784c4c45f0be151a2d3ba017daca7d", size = 382590, upload-time = "2025-10-06T14:10:33.352Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/7f/59ec509abf90eda5048b0bc3e2d7b5099dffdb3e6b127019895ab9d5ef44/yarl-1.22.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:139718f35149ff544caba20fce6e8a2f71f1e39b92c700d8438a0b1d2a631a02", size = 385316, upload-time = "2025-10-06T14:10:35.034Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/84/891158426bc8036bfdfd862fabd0e0fa25df4176ec793e447f4b85cf1be4/yarl-1.22.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e1b51bebd221006d3d2f95fbe124b22b247136647ae5dcc8c7acafba66e5ee67", size = 374431, upload-time = "2025-10-06T14:10:37.76Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/49/03da1580665baa8bef5e8ed34c6df2c2aca0a2f28bf397ed238cc1bbc6f2/yarl-1.22.0-cp313-cp313-win32.whl", hash = "sha256:d3e32536234a95f513bd374e93d717cf6b2231a791758de6c509e3653f234c95", size = 81555, upload-time = "2025-10-06T14:10:39.649Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/ee/450914ae11b419eadd067c6183ae08381cfdfcb9798b90b2b713bbebddda/yarl-1.22.0-cp313-cp313-win_amd64.whl", hash = "sha256:47743b82b76d89a1d20b83e60d5c20314cbd5ba2befc9cda8f28300c4a08ed4d", size = 86965, upload-time = "2025-10-06T14:10:41.313Z" },
-    { url = "https://files.pythonhosted.org/packages/98/4d/264a01eae03b6cf629ad69bae94e3b0e5344741e929073678e84bf7a3e3b/yarl-1.22.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d0fcda9608875f7d052eff120c7a5da474a6796fe4d83e152e0e4d42f6d1a9b", size = 81205, upload-time = "2025-10-06T14:10:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/88/fc/6908f062a2f77b5f9f6d69cecb1747260831ff206adcbc5b510aff88df91/yarl-1.22.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:719ae08b6972befcba4310e49edb1161a88cdd331e3a694b84466bd938a6ab10", size = 146209, upload-time = "2025-10-06T14:10:44.643Z" },
-    { url = "https://files.pythonhosted.org/packages/65/47/76594ae8eab26210b4867be6f49129861ad33da1f1ebdf7051e98492bf62/yarl-1.22.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:47d8a5c446df1c4db9d21b49619ffdba90e77c89ec6e283f453856c74b50b9e3", size = 95966, upload-time = "2025-10-06T14:10:46.554Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/ce/05e9828a49271ba6b5b038b15b3934e996980dd78abdfeb52a04cfb9467e/yarl-1.22.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cfebc0ac8333520d2d0423cbbe43ae43c8838862ddb898f5ca68565e395516e9", size = 97312, upload-time = "2025-10-06T14:10:48.007Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/c5/7dffad5e4f2265b29c9d7ec869c369e4223166e4f9206fc2243ee9eea727/yarl-1.22.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4398557cbf484207df000309235979c79c4356518fd5c99158c7d38203c4da4f", size = 361967, upload-time = "2025-10-06T14:10:49.997Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b2/375b933c93a54bff7fc041e1a6ad2c0f6f733ffb0c6e642ce56ee3b39970/yarl-1.22.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2ca6fd72a8cd803be290d42f2dec5cdcd5299eeb93c2d929bf060ad9efaf5de0", size = 323949, upload-time = "2025-10-06T14:10:52.004Z" },
-    { url = "https://files.pythonhosted.org/packages/66/50/bfc2a29a1d78644c5a7220ce2f304f38248dc94124a326794e677634b6cf/yarl-1.22.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca1f59c4e1ab6e72f0a23c13fca5430f889634166be85dbf1013683e49e3278e", size = 361818, upload-time = "2025-10-06T14:10:54.078Z" },
-    { url = "https://files.pythonhosted.org/packages/46/96/f3941a46af7d5d0f0498f86d71275696800ddcdd20426298e572b19b91ff/yarl-1.22.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5010a52015e7c70f86eb967db0f37f3c8bd503a695a49f8d45700144667708", size = 372626, upload-time = "2025-10-06T14:10:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/42/8b27c83bb875cd89448e42cd627e0fb971fa1675c9ec546393d18826cb50/yarl-1.22.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d7672ecf7557476642c88497c2f8d8542f8e36596e928e9bcba0e42e1e7d71f", size = 341129, upload-time = "2025-10-06T14:10:57.985Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/99ca3122201b382a3cf7cc937b95235b0ac944f7e9f2d5331d50821ed352/yarl-1.22.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3b7c88eeef021579d600e50363e0b6ee4f7f6f728cd3486b9d0f3ee7b946398d", size = 346776, upload-time = "2025-10-06T14:10:59.633Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b4/47328bf996acd01a4c16ef9dcd2f59c969f495073616586f78cd5f2efb99/yarl-1.22.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f4afb5c34f2c6fecdcc182dfcfc6af6cccf1aa923eed4d6a12e9d96904e1a0d8", size = 334879, upload-time = "2025-10-06T14:11:01.454Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/ad/b77d7b3f14a4283bffb8e92c6026496f6de49751c2f97d4352242bba3990/yarl-1.22.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:59c189e3e99a59cf8d83cbb31d4db02d66cda5a1a4374e8a012b51255341abf5", size = 350996, upload-time = "2025-10-06T14:11:03.452Z" },
-    { url = "https://files.pythonhosted.org/packages/81/c8/06e1d69295792ba54d556f06686cbd6a7ce39c22307100e3fb4a2c0b0a1d/yarl-1.22.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:5a3bf7f62a289fa90f1990422dc8dff5a458469ea71d1624585ec3a4c8d6960f", size = 356047, upload-time = "2025-10-06T14:11:05.115Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/b8/4c0e9e9f597074b208d18cef227d83aac36184bfbc6eab204ea55783dbc5/yarl-1.22.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:de6b9a04c606978fdfe72666fa216ffcf2d1a9f6a381058d4378f8d7b1e5de62", size = 342947, upload-time = "2025-10-06T14:11:08.137Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/e5/11f140a58bf4c6ad7aca69a892bff0ee638c31bea4206748fc0df4ebcb3a/yarl-1.22.0-cp313-cp313t-win32.whl", hash = "sha256:1834bb90991cc2999f10f97f5f01317f99b143284766d197e43cd5b45eb18d03", size = 86943, upload-time = "2025-10-06T14:11:10.284Z" },
-    { url = "https://files.pythonhosted.org/packages/31/74/8b74bae38ed7fe6793d0c15a0c8207bbb819cf287788459e5ed230996cdd/yarl-1.22.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff86011bd159a9d2dfc89c34cfd8aff12875980e3bd6a39ff097887520e60249", size = 93715, upload-time = "2025-10-06T14:11:11.739Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/991858aa4b5892d57aef7ee1ba6b4d01ec3b7eb3060795d34090a3ca3278/yarl-1.22.0-cp313-cp313t-win_arm64.whl", hash = "sha256:7861058d0582b847bc4e3a4a4c46828a410bca738673f35a29ba3ca5db0b473b", size = 83857, upload-time = "2025-10-06T14:11:13.586Z" },
-    { url = "https://files.pythonhosted.org/packages/46/b3/e20ef504049f1a1c54a814b4b9bed96d1ac0e0610c3b4da178f87209db05/yarl-1.22.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:34b36c2c57124530884d89d50ed2c1478697ad7473efd59cfd479945c95650e4", size = 140520, upload-time = "2025-10-06T14:11:15.465Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/04/3532d990fdbab02e5ede063676b5c4260e7f3abea2151099c2aa745acc4c/yarl-1.22.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:0dd9a702591ca2e543631c2a017e4a547e38a5c0f29eece37d9097e04a7ac683", size = 93504, upload-time = "2025-10-06T14:11:17.106Z" },
-    { url = "https://files.pythonhosted.org/packages/11/63/ff458113c5c2dac9a9719ac68ee7c947cb621432bcf28c9972b1c0e83938/yarl-1.22.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:594fcab1032e2d2cc3321bb2e51271e7cd2b516c7d9aee780ece81b07ff8244b", size = 94282, upload-time = "2025-10-06T14:11:19.064Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/bc/315a56aca762d44a6aaaf7ad253f04d996cb6b27bad34410f82d76ea8038/yarl-1.22.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3d7a87a78d46a2e3d5b72587ac14b4c16952dd0887dbb051451eceac774411e", size = 372080, upload-time = "2025-10-06T14:11:20.996Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/3f/08e9b826ec2e099ea6e7c69a61272f4f6da62cb5b1b63590bb80ca2e4a40/yarl-1.22.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:852863707010316c973162e703bddabec35e8757e67fcb8ad58829de1ebc8590", size = 338696, upload-time = "2025-10-06T14:11:22.847Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/9f/90360108e3b32bd76789088e99538febfea24a102380ae73827f62073543/yarl-1.22.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:131a085a53bfe839a477c0845acf21efc77457ba2bcf5899618136d64f3303a2", size = 387121, upload-time = "2025-10-06T14:11:24.889Z" },
-    { url = "https://files.pythonhosted.org/packages/98/92/ab8d4657bd5b46a38094cfaea498f18bb70ce6b63508fd7e909bd1f93066/yarl-1.22.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:078a8aefd263f4d4f923a9677b942b445a2be970ca24548a8102689a3a8ab8da", size = 394080, upload-time = "2025-10-06T14:11:27.307Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/e7/d8c5a7752fef68205296201f8ec2bf718f5c805a7a7e9880576c67600658/yarl-1.22.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bca03b91c323036913993ff5c738d0842fc9c60c4648e5c8d98331526df89784", size = 372661, upload-time = "2025-10-06T14:11:29.387Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/2e/f4d26183c8db0bb82d491b072f3127fb8c381a6206a3a56332714b79b751/yarl-1.22.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:68986a61557d37bb90d3051a45b91fa3d5c516d177dfc6dd6f2f436a07ff2b6b", size = 364645, upload-time = "2025-10-06T14:11:31.423Z" },
-    { url = "https://files.pythonhosted.org/packages/80/7c/428e5812e6b87cd00ee8e898328a62c95825bf37c7fa87f0b6bb2ad31304/yarl-1.22.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:4792b262d585ff0dff6bcb787f8492e40698443ec982a3568c2096433660c694", size = 355361, upload-time = "2025-10-06T14:11:33.055Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/2a/249405fd26776f8b13c067378ef4d7dd49c9098d1b6457cdd152a99e96a9/yarl-1.22.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ebd4549b108d732dba1d4ace67614b9545b21ece30937a63a65dd34efa19732d", size = 381451, upload-time = "2025-10-06T14:11:35.136Z" },
-    { url = "https://files.pythonhosted.org/packages/67/a8/fb6b1adbe98cf1e2dd9fad71003d3a63a1bc22459c6e15f5714eb9323b93/yarl-1.22.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f87ac53513d22240c7d59203f25cc3beac1e574c6cd681bbfd321987b69f95fd", size = 383814, upload-time = "2025-10-06T14:11:37.094Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/f9/3aa2c0e480fb73e872ae2814c43bc1e734740bb0d54e8cb2a95925f98131/yarl-1.22.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:22b029f2881599e2f1b06f8f1db2ee63bd309e2293ba2d566e008ba12778b8da", size = 370799, upload-time = "2025-10-06T14:11:38.83Z" },
-    { url = "https://files.pythonhosted.org/packages/50/3c/af9dba3b8b5eeb302f36f16f92791f3ea62e3f47763406abf6d5a4a3333b/yarl-1.22.0-cp314-cp314-win32.whl", hash = "sha256:6a635ea45ba4ea8238463b4f7d0e721bad669f80878b7bfd1f89266e2ae63da2", size = 82990, upload-time = "2025-10-06T14:11:40.624Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/30/ac3a0c5bdc1d6efd1b41fa24d4897a4329b3b1e98de9449679dd327af4f0/yarl-1.22.0-cp314-cp314-win_amd64.whl", hash = "sha256:0d6e6885777af0f110b0e5d7e5dda8b704efed3894da26220b7f3d887b839a79", size = 88292, upload-time = "2025-10-06T14:11:42.578Z" },
-    { url = "https://files.pythonhosted.org/packages/df/0a/227ab4ff5b998a1b7410abc7b46c9b7a26b0ca9e86c34ba4b8d8bc7c63d5/yarl-1.22.0-cp314-cp314-win_arm64.whl", hash = "sha256:8218f4e98d3c10d683584cb40f0424f4b9fd6e95610232dd75e13743b070ee33", size = 82888, upload-time = "2025-10-06T14:11:44.863Z" },
-    { url = "https://files.pythonhosted.org/packages/06/5e/a15eb13db90abd87dfbefb9760c0f3f257ac42a5cac7e75dbc23bed97a9f/yarl-1.22.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:45c2842ff0e0d1b35a6bf1cd6c690939dacb617a70827f715232b2e0494d55d1", size = 146223, upload-time = "2025-10-06T14:11:46.796Z" },
-    { url = "https://files.pythonhosted.org/packages/18/82/9665c61910d4d84f41a5bf6837597c89e665fa88aa4941080704645932a9/yarl-1.22.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d947071e6ebcf2e2bee8fce76e10faca8f7a14808ca36a910263acaacef08eca", size = 95981, upload-time = "2025-10-06T14:11:48.845Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/9a/2f65743589809af4d0a6d3aa749343c4b5f4c380cc24a8e94a3c6625a808/yarl-1.22.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:334b8721303e61b00019474cc103bdac3d7b1f65e91f0bfedeec2d56dfe74b53", size = 97303, upload-time = "2025-10-06T14:11:50.897Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ab/5b13d3e157505c43c3b43b5a776cbf7b24a02bc4cccc40314771197e3508/yarl-1.22.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e7ce67c34138a058fd092f67d07a72b8e31ff0c9236e751957465a24b28910c", size = 361820, upload-time = "2025-10-06T14:11:52.549Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/76/242a5ef4677615cf95330cfc1b4610e78184400699bdda0acb897ef5e49a/yarl-1.22.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d77e1b2c6d04711478cb1c4ab90db07f1609ccf06a287d5607fcd90dc9863acf", size = 323203, upload-time = "2025-10-06T14:11:54.225Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/96/475509110d3f0153b43d06164cf4195c64d16999e0c7e2d8a099adcd6907/yarl-1.22.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4647674b6150d2cae088fc07de2738a84b8bcedebef29802cf0b0a82ab6face", size = 363173, upload-time = "2025-10-06T14:11:56.069Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/66/59db471aecfbd559a1fd48aedd954435558cd98c7d0da8b03cc6c140a32c/yarl-1.22.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efb07073be061c8f79d03d04139a80ba33cbd390ca8f0297aae9cce6411e4c6b", size = 373562, upload-time = "2025-10-06T14:11:58.783Z" },
-    { url = "https://files.pythonhosted.org/packages/03/1f/c5d94abc91557384719da10ff166b916107c1b45e4d0423a88457071dd88/yarl-1.22.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e51ac5435758ba97ad69617e13233da53908beccc6cfcd6c34bbed8dcbede486", size = 339828, upload-time = "2025-10-06T14:12:00.686Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/97/aa6a143d3afba17b6465733681c70cf175af89f76ec8d9286e08437a7454/yarl-1.22.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:33e32a0dd0c8205efa8e83d04fc9f19313772b78522d1bdc7d9aed706bfd6138", size = 347551, upload-time = "2025-10-06T14:12:02.628Z" },
-    { url = "https://files.pythonhosted.org/packages/43/3c/45a2b6d80195959239a7b2a8810506d4eea5487dce61c2a3393e7fc3c52e/yarl-1.22.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:bf4a21e58b9cde0e401e683ebd00f6ed30a06d14e93f7c8fd059f8b6e8f87b6a", size = 334512, upload-time = "2025-10-06T14:12:04.871Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a0/c2ab48d74599c7c84cb104ebd799c5813de252bea0f360ffc29d270c2caa/yarl-1.22.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:e4b582bab49ac33c8deb97e058cd67c2c50dac0dd134874106d9c774fd272529", size = 352400, upload-time = "2025-10-06T14:12:06.624Z" },
-    { url = "https://files.pythonhosted.org/packages/32/75/f8919b2eafc929567d3d8411f72bdb1a2109c01caaab4ebfa5f8ffadc15b/yarl-1.22.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0b5bcc1a9c4839e7e30b7b30dd47fe5e7e44fb7054ec29b5bb8d526aa1041093", size = 357140, upload-time = "2025-10-06T14:12:08.362Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/72/6a85bba382f22cf78add705d8c3731748397d986e197e53ecc7835e76de7/yarl-1.22.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c0232bce2170103ec23c454e54a57008a9a72b5d1c3105dc2496750da8cfa47c", size = 341473, upload-time = "2025-10-06T14:12:10.994Z" },
-    { url = "https://files.pythonhosted.org/packages/35/18/55e6011f7c044dc80b98893060773cefcfdbf60dfefb8cb2f58b9bacbd83/yarl-1.22.0-cp314-cp314t-win32.whl", hash = "sha256:8009b3173bcd637be650922ac455946197d858b3630b6d8787aa9e5c4564533e", size = 89056, upload-time = "2025-10-06T14:12:13.317Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
-    { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/72/f704a97aac430aeb704fa16435dfa24fbeaf087d46724d0965eb1f756a2c/bandit-1.9.2.tar.gz", hash = "sha256:32410415cd93bf9c8b91972159d5cf1e7f063a9146d70345641cd3877de348ce", size = 4241659, upload-time = "2025-11-23T21:36:18.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/1a/5b0320642cca53a473e79c7d273071b5a9a8578f9e370b74da5daa2768d7/bandit-1.9.2-py3-none-any.whl", hash = "sha256:bda8d68610fc33a6e10b7a8f1d61d92c8f6c004051d5e946406be1fb1b16a868", size = 134377, upload-time = "2025-11-23T21:36:17.39Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -634,6 +649,11 @@ gmail = [
     { name = "google-auth-oauthlib" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
@@ -672,6 +692,9 @@ requires-dist = [
     { name = "yamllint", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev", "gmail"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "bandit", specifier = ">=1.9.2" }]
 
 [[package]]
 name = "maison"
@@ -2055,6 +2078,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/5b/496f8abebd10c3301129abba7ddafd46c71d799a70c44ab080323987c4c9/stevedore-5.6.0.tar.gz", hash = "sha256:f22d15c6ead40c5bbfa9ca54aa7e7b4a07d59b36ae03ed12ced1a54cf0b51945", size = 516074, upload-time = "2025-11-20T10:06:07.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/40/8561ce06dc46fd17242c7724ab25b257a2ac1b35f4ebf551b40ce6105cfa/stevedore-5.6.0-py3-none-any.whl", hash = "sha256:4a36dccefd7aeea0c70135526cecb7766c4c84c473b1af68db23d541b6dc1820", size = 54428, upload-time = "2025-11-20T10:06:05.946Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

  - **Implement MLX-based classification with SemanticRouter** - New local AI classification using Apple Silicon optimized MLX framework with semantic embeddings for fast, accurate email categorization
  - **Add data management utilities and CLI commands** - New cleanup, db-stats, and prune-db commands for maintaining classification databases
  - **Add hierarchical CLAUDE.md documentation** - Improved codebase context for AI assistants
  - **Fix all quality issues** - Tests, linting, and security fixes ensuring 241 tests pass with 75% coverage

  ## Key Changes

  ### New Features
  - `SemanticRouter` class using nomic embeddings for semantic similarity matching
  - `MLXLLM` class for local LLM inference on Apple Silicon
  - Data cleanup utilities (`cleanup`, `db-stats`, `prune-db` CLI commands)
  - Comprehensive test coverage for all new modules

  ### Technical Details
  - Uses `sentence-transformers` with nomic-ai embeddings
  - MLX-LM integration with proper sampler API
  - 42 files changed, +5274/-1201 lines

  ## Test plan

  - [x] All 241 tests passing
  - [x] Ruff linting clean
  - [x] Code formatting verified
  - [x] 75% test coverage maintained