### PR TITLE
chore: prepare default branch rename maincd -> main (zero-gap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MailTag is a Python-based email automation tool that classifies and organizes em
 [![GitHub Release](https://img.shields.io/github/v/release/fjacquet/mailtag)](https://github.com/fjacquet/mailtag/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![codecov](https://codecov.io/gh/fjacquet/mailtag/branch/maincd/graph/badge.svg)](https://codecov.io/gh/fjacquet/mailtag)
+[![codecov](https://codecov.io/gh/fjacquet/mailtag/branch/main/graph/badge.svg)](https://codecov.io/gh/fjacquet/mailtag)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://fjacquet.github.io/mailtag/)
 
 ## How It Works

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -5,7 +5,7 @@ AI-powered email classification and organization using on-device inference.
 [![CI Tests and Checks](https://github.com/fjacquet/mailtag/actions/workflows/ci.yml/badge.svg)](https://github.com/fjacquet/mailtag/actions/workflows/ci.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/fjacquet/mailtag)](https://github.com/fjacquet/mailtag/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/fjacquet/mailtag/blob/maincd/LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/fjacquet/mailtag/blob/main/LICENSE)
 
 ## What is MailTag?
 


### PR DESCRIPTION
Part of safely renaming the default branch from `maincd` (a typo) to `main`.

## What this PR does
- Updates non-workflow doc references that hard-code the `maincd` branch name in URLs:
  - `README.md` codecov badge -> `branch/main`
  - `docs-site/index.md` MIT license link -> `blob/main`

## Zero-gap CI note
The workflows (`ci.yml`, `docs.yml`) already dual-trigger on `branches: [main, maincd]`, so CI keeps firing across the rename with no gap. The transitional `maincd` trigger is removed in a follow-up cleanup PR **after** the branch rename.

Branch protection settings and `dependabot-automerge.yml` are intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)