### PR TITLE
chore: drop transitional maincd branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@
 name: CI Tests and Checks
 on:
   push:
-    branches: [main, maincd]
+    branches: [main]
   pull_request:
-    branches: [main, maincd]
+    branches: [main]
   workflow_dispatch:
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@
 name: Deploy Docs
 on:
   push:
-    branches: [main, maincd]
+    branches: [main]
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
Cleanup after renaming the default branch from `maincd` (typo) to `main`.

The dual trigger `branches: [main, maincd]` in `ci.yml` and `docs.yml` kept CI firing with zero gap across the rename. Now that `main` is the default branch, this PR removes the obsolete `maincd` trigger.

After this merges, no `maincd` references remain anywhere in the repo (verified with a fresh-clone `grep -rn maincd`).

Branch protection and `dependabot-automerge.yml` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)