### PR TITLE
chore: fleet health refresh

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,3 +75,6 @@ markdown_extensions:
       alternate_style: true
   - toc:
       permalink: true
+
+extra:
+  version: v1.0.2


### PR DESCRIPTION
Fleet health audit + refresh (docs-only).

- mkdocs — refreshed: canonical repo_url/repo_name + mkdocs-material `extra.version` = v1.0.2
- Release n/a (no publish mechanism).

No application-code changes.